### PR TITLE
Part 2 - Chéo hóa ma trận (Diagonalization) & Phân rã giá trị kỳ dị SVD (Singular Value Decomposition)

### DIFF
--- a/part2/decomposition.py
+++ b/part2/decomposition.py
@@ -17,6 +17,26 @@ def svdDecomp(matA):
         colV = getColumn(matV, i)
         evPairs.append((evs[i], colV))
     evPairs.sort(key=lambda x: x[0], reverse=True)
+    
+    ortho_V_cols = []
+    for i in range(n):
+        v = list(evPairs[i][1])
+        for u in ortho_V_cols:
+            dot_uv = sum(x*y for x, y in zip(v, u))
+            v = [x - dot_uv * y for x, y in zip(v, u)]
+        norm = math.sqrt(sum(x*x for x in v))
+        if norm > 1e-9:
+            v = [x/norm for x in v]
+        else:
+            v = [1.0 if j == i else 0.0 for j in range(n)]
+            for u in ortho_V_cols:
+                dot_uv = sum(x*y for x, y in zip(v, u))
+                v = [x - dot_uv * y for x, y in zip(v, u)]
+            norm = math.sqrt(sum(x*x for x in v))
+            if norm > 1e-9: v = [x/norm for x in v]
+        ortho_V_cols.append(v)
+        evPairs[i] = (evPairs[i][0], v)
+
     singularVals = []
     matVSorted = [[0.0 for col in range(n)] for row in range(n)]
     # Lấy các giá trị kỳ dị bằng căn bậc 2 của các trị riêng dương
@@ -73,7 +93,6 @@ def verifySvd(matA, matU, matSigma, matVT):
     # So sánh các giá trị kỳ dị (chỉ lưu min(m, n) phần tử)
     mySingularVals = [matSigma[i][i] for i in range(min(len(matA), len(matA[0])))]
     errSv = np.max(np.abs(np.array(mySingularVals) - arrS))
-    
     print(f"Sai số giá trị kỳ dị so với NumPy = {errSv:.2e}")
     return maxError < 1e-4 and errSv < 1e-4
 

--- a/part2/decomposition.py
+++ b/part2/decomposition.py
@@ -6,6 +6,12 @@ def svdDecomp(matA):
     # Phân rã SVD cho ma trận m x n: A = U * Sigma * V^T
     m = len(matA)
     n = len(matA[0])
+    
+    for row in matA:
+        for val in row:
+            if math.isnan(val) or math.isinf(val):
+                raise ValueError("Ma trận chứa giá trị NaN hoặc Inf không hợp lệ.")
+                
     # Tính tích A^T * A
     matATranspose = matrixTranspose(matA)
     matAtA = matrixMultiply(matATranspose, matA)
@@ -86,15 +92,29 @@ def verifySvd(matA, matU, matSigma, matVT):
     print("* Kiểm chứng SVD")
     print(f"Sai số tái cấu trúc ||A - U*Sigma*V^T||max = {maxError:.2e}")
     if maxError < 1e-4:
-        print("- Cài đặt SVD đúng (A ~ U Sigma V^T).")
+        print("Cài đặt SVD đúng (A ~ U*Sigma*V^T).")
     else:
-        print("- Cài đặt SVD có thể có sai số cao.")
+        print("Cài đặt SVD có thể có sai số cao.")
     arrS = np.linalg.svd(arrA)[1]
     # So sánh các giá trị kỳ dị (chỉ lưu min(m, n) phần tử)
     mySingularVals = [matSigma[i][i] for i in range(min(len(matA), len(matA[0])))]
     errSv = np.max(np.abs(np.array(mySingularVals) - arrS))
     print(f"Sai số giá trị kỳ dị so với NumPy = {errSv:.2e}")
     return maxError < 1e-4 and errSv < 1e-4
+
+def demo_svd(matA):
+    matU, matSigma, matVT = svdDecomp(matA)
+    print("\n* Kết quả phân rã SVD")
+    print("Ma trận U (Left Singular Vectors):")
+    for row in matU:
+        print("  " + " ".join(f"{val:8.4f}" for val in row))
+    print("\nMa trận kích thước m x n Sigma (Singular Values):")
+    for row in matSigma:
+        print("  " + " ".join(f"{val:8.4f}" for val in row))
+    print("\nMa trận V^T (Right Singular Vectors Transposed):")
+    for row in matVT:
+        print("  " + " ".join(f"{val:8.4f}" for val in row))
+    verifySvd(matA, matU, matSigma, matVT)
 
 def main():
     try:
@@ -108,18 +128,7 @@ def main():
                 print(f"Lỗi: Dòng {i+1} không có đủ {cols} phần tử. Vui lòng thử lại.")
                 exit()
             matA.append(row)
-        matU, matSigma, matVT = svdDecomp(matA)
-        print("\n* Kết quả phân rã SVD")
-        print("Ma trận U (Left Singular Vectors):")
-        for row in matU:
-            print("  " + " ".join(f"{val:8.4f}" for val in row))
-        print("\nMa trận kích thước m x n Sigma (Singular Values):")
-        for row in matSigma:
-            print("  " + " ".join(f"{val:8.4f}" for val in row))
-        print("\nMa trận V^T (Right Singular Vectors Transposed):")
-        for row in matVT:
-            print("  " + " ".join(f"{val:8.4f}" for val in row))
-        verifySvd(matA, matU, matSigma, matVT)
+        demo_svd(matA)
     except ValueError:
         print("Lỗi: Dữ liệu nhập vào chưa hợp lệ.")
 

--- a/part2/decomposition.py
+++ b/part2/decomposition.py
@@ -1,0 +1,108 @@
+import math
+import numpy as np
+from diagonalization import matrixMultiply, matrixTranspose, findEigen, getColumn
+
+def svdDecomp(matA):
+    # Phân rã SVD cho ma trận m x n: A = U * Sigma * V^T
+    m = len(matA)
+    n = len(matA[0])
+    # Tính tích A^T * A
+    matATranspose = matrixTranspose(matA)
+    matAtA = matrixMultiply(matATranspose, matA)
+    # Tìm giá trị riêng và vector riêng
+    evs, matV = findEigen(matAtA)
+    # Sắp xếp các giá trị riêng giảm dần kèm theo vector riêng tương ứng
+    evPairs = []
+    for i in range(n):
+        colV = getColumn(matV, i)
+        evPairs.append((evs[i], colV))
+    evPairs.sort(key=lambda x: x[0], reverse=True)
+    singularVals = []
+    matVSorted = [[0.0 for col in range(n)] for row in range(n)]
+    # Lấy các giá trị kỳ dị bằng căn bậc 2 của các trị riêng dương
+    for i in range(n):
+        val = evPairs[i][0]
+        if val < 1e-9:
+            val = 0.0
+        singularVals.append(math.sqrt(val))
+        for j in range(n):
+            matVSorted[j][i] = evPairs[i][1][j]
+    # Xây dựng ma trận Sigma kích thước m x n
+    matSigma = [[0.0 for col in range(n)] for row in range(m)]
+    for i in range(min(m, n)):
+        matSigma[i][i] = singularVals[i]
+    # Tạo ma trận U cỡ m x m
+    colsU = []
+    for i in range(min(m, n)):
+        if singularVals[i] > 1e-9:
+            vecI = [[matVSorted[j][i]] for j in range(n)]
+            AVecI = matrixMultiply(matA, vecI)
+            uCol = [AVecI[j][0] / singularVals[i] for j in range(m)]
+            colsU.append(uCol)
+    for i in range(m):
+        if len(colsU) == m:
+            break
+        tempV = [0.0] * m
+        tempV[i] = 1.0
+        for existU in colsU:
+            dotProd = sum([tempV[k] * existU[k] for k in range(m)])
+            for k in range(m):
+                tempV[k] -= dotProd * existU[k]
+        norm = math.sqrt(sum([val**2 for val in tempV]))
+        if norm > 1e-9:
+            newU = [tempV[k] / norm for k in range(m)]
+            colsU.append(newU)
+    matU = matrixTranspose(colsU)
+    matVTranspose = matrixTranspose(matVSorted)
+    return matU, matSigma, matVTranspose
+
+def verifySvd(matA, matU, matSigma, matVT):
+    arrA = np.array(matA, dtype=float)
+    arrU = np.array(matU, dtype=float)
+    arrSigma = np.array(matSigma, dtype=float)
+    arrVT = np.array(matVT, dtype=float)
+    arrRebuilt = arrU @ arrSigma @ arrVT
+    maxError = np.max(np.abs(arrA - arrRebuilt))
+    print("* Kiểm chứng SVD")
+    print(f"Sai số tái cấu trúc ||A - U*Sigma*V^T||max = {maxError:.2e}")
+    if maxError < 1e-4:
+        print("- Cài đặt SVD đúng (A ~ U Sigma V^T).")
+    else:
+        print("- Cài đặt SVD có thể có sai số cao.")
+    arrS = np.linalg.svd(arrA)[1]
+    # So sánh các giá trị kỳ dị (chỉ lưu min(m, n) phần tử)
+    mySingularVals = [matSigma[i][i] for i in range(min(len(matA), len(matA[0])))]
+    errSv = np.max(np.abs(np.array(mySingularVals) - arrS))
+    
+    print(f"Sai số giá trị kỳ dị so với NumPy = {errSv:.2e}")
+    return maxError < 1e-4 and errSv < 1e-4
+
+def main():
+    try:
+        rows = int(input("Nhập số dòng m = "))
+        cols = int(input("Nhập số cột n = "))
+        print(f"Nhập ma trận {rows}x{cols} (mỗi dòng cách nhau bởi dấu Enter, các phần tử cách nhau bởi khoảng trắng):")
+        matA = []
+        for i in range(rows):
+            row = list(map(float, input().strip().split()))
+            if len(row) != cols:
+                print(f"Lỗi: Dòng {i+1} không có đủ {cols} phần tử. Vui lòng thử lại.")
+                exit()
+            matA.append(row)
+        matU, matSigma, matVT = svdDecomp(matA)
+        print("\n* Kết quả phân rã SVD")
+        print("Ma trận U (Left Singular Vectors):")
+        for row in matU:
+            print("  " + " ".join(f"{val:8.4f}" for val in row))
+        print("\nMa trận kích thước m x n Sigma (Singular Values):")
+        for row in matSigma:
+            print("  " + " ".join(f"{val:8.4f}" for val in row))
+        print("\nMa trận V^T (Right Singular Vectors Transposed):")
+        for row in matVT:
+            print("  " + " ".join(f"{val:8.4f}" for val in row))
+        verifySvd(matA, matU, matSigma, matVT)
+    except ValueError:
+        print("Lỗi: Dữ liệu nhập vào chưa hợp lệ.")
+
+if __name__ == "__main__":
+    main()

--- a/part2/diagonalization.py
+++ b/part2/diagonalization.py
@@ -1,0 +1,230 @@
+import math
+import numpy as np
+import cmath
+
+def getColumn(matrix, colIndex):
+    return [row[colIndex] for row in matrix]
+
+def matrixMultiply(matA, matB):
+    rowsA = len(matA)
+    colsA = len(matA[0])
+    colsB = len(matB[0])
+    result = [[0.0 for col in range(colsB)] for row in range(rowsA)]
+    for i in range(rowsA):
+        for j in range(colsB):
+            sumProd = 0.0
+            for k in range(colsA):
+                sumProd += matA[i][k] * matB[k][j]
+            result[i][j] = sumProd
+    return result
+
+def matrixTranspose(matrix):
+    rows = len(matrix)
+    cols = len(matrix[0])
+    result = [[0.0 for row in range(rows)] for col in range(cols)]
+    for i in range(rows):
+        for j in range(cols):
+            result[j][i] = matrix[i][j]
+    return result
+
+def gaussInverse(matrix):
+    n = len(matrix)
+    augMat = [row[:] + [1.0 if i == j else 0.0 for step in range(n)] for i, row in enumerate(matrix)]
+    for i in range(n):
+        pivot = augMat[i][i]
+        if abs(pivot) < 1e-9:
+            for k in range(i + 1, n):
+                if abs(augMat[k][i]) > abs(pivot):
+                    augMat[i], augMat[k] = augMat[k], augMat[i]
+                    pivot = augMat[i][i]
+                    break
+        for j in range(2 * n):
+            augMat[i][j] /= pivot
+        for k in range(n):
+            if k != i:
+                factor = augMat[k][i]
+                for j in range(2 * n):
+                    augMat[k][j] -= factor * augMat[i][j]
+    return [row[n:] for row in augMat]
+
+def charPoly(matrix):
+    # Trả về mảng hệ số đa thức đặc trưng [cn, c(n-1), ..., c0]
+    n = len(matrix)
+    c = [1.0]
+    matB = [[1.0 if i == j else 0.0 for j in range(n)] for i in range(n)]
+    for k in range(1, n + 1):
+        if k == 1:
+            matM = matrix
+        else:
+            matM = matrixMultiply(matrix, matB)
+        traceM = sum(matM[i][i] for i in range(n))
+        ak = - traceM / k
+        c.append(ak)
+        matB = [[matM[i][j] + (ak if i == j else 0.0) for j in range(n)] for i in range(n)]
+    return c
+
+def findRoots(coeffs):
+    # Tìm các rễ phương trình đa thức đặc trưng
+    n = len(coeffs) - 1
+    roots = [cmath.rect(1.5, 2 * math.pi * k / n) for k in range(n)]
+    for step in range(150):
+        for k in range(n):
+            polyVal = 0.0
+            for j in range(n + 1):
+                polyVal += coeffs[j] * (roots[k] ** (n - j))
+            den = 1.0
+            for j in range(n):
+                if j != k:
+                    den *= (roots[k] - roots[j])
+            if abs(den) > 1e-15:
+                roots[k] -= polyVal / den
+    return [float(x.real) for x in roots if abs(x.imag) < 1e-3]
+
+def gaussBasis(matrix, ev):
+    # Cài đặt thuật toán khử Gauss trên (A - lambda * I)x = 0 để lấy không gian nghiệm
+    n = len(matrix)
+    matM = [[matrix[i][j] - (ev if i == j else 0.0) for j in range(n)] for i in range(n)]
+    pivotCols = []
+    lead = 0
+    aug = [row[:] for row in matM]
+    for r in range(n):
+        if lead >= n:
+            break
+        maxVal = 0.0
+        maxIdx = r
+        for i in range(r, n):
+            if abs(aug[i][lead]) > maxVal:
+                maxVal = abs(aug[i][lead])
+                maxIdx = i
+        if maxVal < 1e-6:
+            lead += 1
+            continue
+        aug[maxIdx], aug[r] = aug[r], aug[maxIdx]
+        pivotCols.append(lead)
+        lv = aug[r][lead]
+        for j in range(n):
+            aug[r][j] /= lv
+        for i in range(n):
+            if i != r:
+                lv = aug[i][lead]
+                for j in range(n):
+                    aug[i][j] -= lv * aug[r][j]
+        lead += 1
+    freeCols = [j for j in range(n) if j not in pivotCols]
+    if not freeCols:
+        if pivotCols:
+            pivotCols.pop()
+        freeCols.append(n - 1)
+    basis = []
+    for f in freeCols:
+        v = [0.0] * n
+        v[f] = 1.0
+        for rIdx, pCol in enumerate(pivotCols):
+            if rIdx < n:
+                v[pCol] = -aug[rIdx][f]
+        norm = math.sqrt(sum(x*x for x in v))
+        if norm > 1e-9:
+            v = [x/norm for x in v]
+        basis.append(v)
+    return basis
+
+def findEigen(matrix):
+    # Detect bậc
+    n = len(matrix)
+    if n <= 4:
+        # Bậc <= 4: Dùng khử Gauss
+        coeffs = charPoly(matrix)
+        evs = findRoots(coeffs)
+        evs.sort(reverse=True)
+        uniqueEvs = []
+        for ev in evs:
+            if not any(abs(ev - u) < 1e-4 for u in uniqueEvs):
+                uniqueEvs.append(ev)  
+        finalEvs = []
+        pRows = []
+        for ev in uniqueEvs:
+            basis = gaussBasis(matrix, ev)
+            for vec in basis:
+                finalEvs.append(ev)
+                pRows.append(vec)
+        # Phân phối và giới hạn lại số chiều vector tương ứng bậc N
+        sortedPairs = sorted(zip(finalEvs, pRows), key=lambda x: x[0], reverse=True)
+        sortedEvs = [p[0] for p in sortedPairs][:n]
+        sortedVecs = [p[1] for p in sortedPairs][:n]
+        # Bổ sung vector fallback cho tình trạng zero pivot array loss
+        while len(sortedEvs) < n:
+            sortedEvs.append(0.0)
+            extraV = [0.0] * n
+            extraV[len(sortedEvs) - 1] = 1.0
+            sortedVecs.append(extraV)
+        return sortedEvs, matrixTranspose(sortedVecs)
+    else:
+        # Bậc > 4: Dùng thư viện numpy.linalg.eig
+        arrM = np.array(matrix, dtype=float)
+        npEvs, npEvecs = np.linalg.eig(arrM)
+        npEvs = npEvs.real
+        npEvecs = npEvecs.real
+        # Sắp xếp giảm dần để đồng nhất
+        idx = np.argsort(npEvs)[::-1]
+        npEvs = npEvs[idx]
+        npEvecs = npEvecs[:, idx]
+        return npEvs.tolist(), npEvecs.tolist()
+
+def diagonalize(matrix):
+    # Chéo hóa ma trận thành A = P * D * P^-1
+    n = len(matrix)
+    evs, matP = findEigen(matrix)
+    matD = [[0.0 for col in range(n)] for row in range(n)]
+    for i in range(n):
+        matD[i][i] = evs[i]  
+    matPInv = gaussInverse(matP)
+    return matP, matD, matPInv
+
+def verify(matrixA, matP, matD, matPInv):
+    # Sử dụng Numpy để đổi trọng số sai số
+    arrA = np.array(matrixA, dtype=float)
+    arrP = np.array(matP, dtype=float)
+    arrD = np.array(matD, dtype=float)
+    arrPInv = np.array(matPInv, dtype=float)
+    arrRebuilt = arrP @ arrD @ arrPInv
+    maxError = np.max(np.abs(arrA - arrRebuilt))
+    print("* Kiểm chứng chéo hóa")
+    print(f"Sai số tái cấu trúc ||A - P*D*P^-1||max = {maxError:.2e}")
+    if maxError < 1e-4:
+        print("Cài đặt chéo hóa đúng (A ~ P D P^-1).")
+    else:
+        print("Cài đặt chéo hóa có thể có sai số cao.")   
+    arrEvs = np.linalg.eig(arrA)[0]
+    myEvs = np.diag(arrD)
+    errEv = np.max(np.abs(np.sort(myEvs)[::-1] - np.sort(arrEvs.real)[::-1]))
+    print(f"Sai số giá trị riêng so với NumPy = {errEv:.2e}")
+    return maxError < 1e-4 and errEv < 1e-4
+
+def main():
+    try:
+        size = int(input("Nhập kích thước ma trận vuông n = "))
+        print(f"Nhập ma trận {size}x{size} (mỗi dòng cách nhau bởi dấu Enter, các phần tử cách nhau bởi khoảng trắng):")
+        matA = []
+        for i in range(size):
+            row = list(map(float, input().strip().split()))
+            if len(row) != size:
+                print(f"Lỗi: Dòng {i+1} không có đủ {size} phần tử. Vui lòng thử lại.")
+                exit()
+            matA.append(row)
+        matP, matD, matPInv = diagonalize(matA)
+        print("\n* Kết quả chéo hóa")
+        print("Ma trận đổi cơ sở P (Các vector riêng nằm trên các cột):")
+        for row in matP:
+            print("  " + " ".join(f"{val:8.4f}" for val in row))
+        print("\nMa trận đường chéo D (Các giá trị riêng):")
+        for row in matD:
+            print("  " + " ".join(f"{val:8.4f}" for val in row))
+        print("\nMa trận P^-1:")
+        for row in matPInv:
+            print("  " + " ".join(f"{val:8.4f}" for val in row))
+        verify(matA, matP, matD, matPInv)
+    except ValueError:
+        print("Lỗi: Dữ liệu nhập vào chưa hợp lệ.")
+
+if __name__ == "__main__":
+    main()

--- a/part2/diagonalization.py
+++ b/part2/diagonalization.py
@@ -195,6 +195,37 @@ def findEigen(matrix):
         npEvecs = npEvecs[:, idx]
         return npEvs.tolist(), npEvecs.tolist()
 
+def checkDiagonalizable(evs, matP):
+    n = len(evs)
+    distinct = True
+    for i in range(n):
+        for j in range(i + 1, n):
+            if abs(evs[i] - evs[j]) < 1e-4:
+                distinct = False
+                break
+        if not distinct:
+            break
+    if distinct:
+        return True, "Ma trận thỏa mãn điều kiện đủ: Có n giá trị riêng phân biệt."
+    # Điều kiện cần và đủ: A có n vector riêng độc lập tuyến tính
+    mat = [row[:] for row in matP]
+    for i in range(n):
+        pivot = mat[i][i]
+        if abs(pivot) < 1e-9:
+            for k in range(i + 1, n):
+                if abs(mat[k][i]) > abs(pivot):
+                    mat[i], mat[k] = mat[k], mat[i]
+                    pivot = mat[i][i]
+                    break
+        if abs(pivot) < 1e-9:
+            return False, "Ma trận không chéo hóa được: Không đủ n vector riêng độc lập tuyến tính."
+        for k in range(i + 1, n):
+            factor = mat[k][i] / pivot
+            for j in range(i, n):
+                mat[k][j] -= factor * mat[i][j]
+                
+    return True
+
 def diagonalize(matrix):
     # Chéo hóa ma trận thành A = P * D * P^-1
     n = len(matrix)
@@ -202,6 +233,12 @@ def diagonalize(matrix):
     matD = [[0.0 for col in range(n)] for row in range(n)]
     for i in range(n):
         matD[i][i] = evs[i]  
+        
+    is_diag = checkDiagonalizable(evs, matP)
+    
+    if not is_diag:
+        raise ValueError("Lỗi: Ma trận không thể chéo hóa được do không thỏa điều kiện.")
+        
     matPInv = gaussInverse(matP)
     return matP, matD, matPInv
 
@@ -216,14 +253,28 @@ def verify(matrixA, matP, matD, matPInv):
     print("* Kiểm chứng chéo hóa")
     print(f"Sai số tái cấu trúc ||A - P*D*P^-1||max = {maxError:.2e}")
     if maxError < 1e-4:
-        print("Cài đặt chéo hóa đúng (A ~ P D P^-1).")
+        print("Cài đặt chéo hóa đúng (A ~ P*D*P^-1).")
     else:
         print("Cài đặt chéo hóa có thể có sai số cao.")   
-    arrEvs = np.linalg.eig(arrA)[0]
+    arrEvs = np.linalg.eigvals(arrA)
     myEvs = np.diag(arrD)
     errEv = np.max(np.abs(np.sort(myEvs)[::-1] - np.sort(arrEvs.real)[::-1]))
     print(f"Sai số giá trị riêng so với NumPy = {errEv:.2e}")
     return maxError < 1e-4 and errEv < 1e-4
+
+def demo_diagonalize(matA):
+    matP, matD, matPInv = diagonalize(matA)
+    print("\n* Kết quả chéo hóa")
+    print("Ma trận đổi cơ sở P (Các vector riêng nằm trên các cột):")
+    for row in matP:
+        print("  " + " ".join(f"{val:8.4f}" for val in row))
+    print("\nMa trận đường chéo D (Các giá trị riêng):")
+    for row in matD:
+        print("  " + " ".join(f"{val:8.4f}" for val in row))
+    print("\nMa trận P^-1:")
+    for row in matPInv:
+        print("  " + " ".join(f"{val:8.4f}" for val in row))
+    return verify(matA, matP, matD, matPInv)
 
 def main():
     try:
@@ -236,18 +287,7 @@ def main():
                 print(f"Lỗi: Dòng {i+1} không có đủ {size} phần tử. Vui lòng thử lại.")
                 exit()
             matA.append(row)
-        matP, matD, matPInv = diagonalize(matA)
-        print("\n* Kết quả chéo hóa")
-        print("Ma trận đổi cơ sở P (Các vector riêng nằm trên các cột):")
-        for row in matP:
-            print("  " + " ".join(f"{val:8.4f}" for val in row))
-        print("\nMa trận đường chéo D (Các giá trị riêng):")
-        for row in matD:
-            print("  " + " ".join(f"{val:8.4f}" for val in row))
-        print("\nMa trận P^-1:")
-        for row in matPInv:
-            print("  " + " ".join(f"{val:8.4f}" for val in row))
-        verify(matA, matP, matD, matPInv)
+        demo_diagonalize(matA)
     except ValueError:
         print("Lỗi: Dữ liệu nhập vào chưa hợp lệ.")
 

--- a/part2/diagonalization.py
+++ b/part2/diagonalization.py
@@ -83,13 +83,13 @@ def findRoots(coeffs):
 def gaussBasis(matrix, ev):
     # Cài đặt thuật toán khử Gauss trên (A - lambda * I)x = 0 để lấy không gian nghiệm
     n = len(matrix)
-    matM = [[matrix[i][j] - (ev if i == j else 0.0) for j in range(n)] for i in range(n)]
-    pivotCols = []
+    aug = [[matrix[i][j] - (ev if i == j else 0.0) for j in range(n)] for i in range(n)]
+    
     lead = 0
-    aug = [row[:] for row in matM]
-    for r in range(n):
-        if lead >= n:
-            break
+    pivotCols = []
+    pivotRows = []
+    r = 0
+    while r < n and lead < n:
         maxVal = 0.0
         maxIdx = r
         for i in range(r, n):
@@ -101,6 +101,7 @@ def gaussBasis(matrix, ev):
             continue
         aug[maxIdx], aug[r] = aug[r], aug[maxIdx]
         pivotCols.append(lead)
+        pivotRows.append(r)
         lv = aug[r][lead]
         for j in range(n):
             aug[r][j] /= lv
@@ -109,24 +110,48 @@ def gaussBasis(matrix, ev):
                 lv = aug[i][lead]
                 for j in range(n):
                     aug[i][j] -= lv * aug[r][j]
+        r += 1
         lead += 1
+        
     freeCols = [j for j in range(n) if j not in pivotCols]
     if not freeCols:
         if pivotCols:
             pivotCols.pop()
+            pivotRows.pop()
         freeCols.append(n - 1)
+        
     basis = []
     for f in freeCols:
         v = [0.0] * n
         v[f] = 1.0
-        for rIdx, pCol in enumerate(pivotCols):
-            if rIdx < n:
-                v[pCol] = -aug[rIdx][f]
+        for i, pCol in enumerate(pivotCols):
+            rIdx = pivotRows[i]
+            v[pCol] = -aug[rIdx][f]
+        basis.append(v)
+        
+    ortho_basis = []
+    for v in basis:
+        for u in ortho_basis:
+            dot_uv = sum(x*y for x, y in zip(v, u))
+            v = [x - dot_uv * y for x, y in zip(v, u)]
         norm = math.sqrt(sum(x*x for x in v))
         if norm > 1e-9:
             v = [x/norm for x in v]
-        basis.append(v)
-    return basis
+            ortho_basis.append(v)
+            
+    while len(ortho_basis) < len(freeCols):
+        extraV = [0.0] * n
+        for i in range(n):
+            extraV[i] = 1.0 if len(ortho_basis) == i else 0.0
+        for u in ortho_basis:
+            dot_uv = sum(x*y for x, y in zip(extraV, u))
+            extraV = [x - dot_uv * y for x, y in zip(extraV, u)]
+        norm = math.sqrt(sum(x*x for x in extraV))
+        if norm > 1e-9:
+            extraV = [x/norm for x in extraV]
+            ortho_basis.append(extraV)
+            
+    return ortho_basis
 
 def findEigen(matrix):
     # Detect bậc

--- a/part2/diagonalization.py
+++ b/part2/diagonalization.py
@@ -29,7 +29,7 @@ def matrixTranspose(matrix):
 
 def gaussInverse(matrix):
     n = len(matrix)
-    augMat = [row[:] + [1.0 if i == j else 0.0 for step in range(n)] for i, row in enumerate(matrix)]
+    augMat = [row[:] + [1.0 if i == j else 0.0 for j in range(n)] for i, row in enumerate(matrix)]
     for i in range(n):
         pivot = augMat[i][i]
         if abs(pivot) < 1e-9:

--- a/part2/test.ipynb
+++ b/part2/test.ipynb
@@ -1,0 +1,363 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Tài liệu Kiểm thử (Test Cases): Chéo hóa Ma trận và Phân rã SVD\n",
+        "\n",
+        "Dựa vào đặc tả trong `test.md`, Notebook này đóng vai trò tự động hóa việc đưa các ma trận thử nghiệm (với độ khó tăng dần và đầy đủ các trường hợp cạnh/lỗi) vào hai hàm cốt lõi `demo_diagonalize` và `demo_svd` nhằm rà soát tính ổn định của hệ thống."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import math\n",
+        "from decomposition import demo_svd\n",
+        "from diagonalization import demo_diagonalize"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 1. Phép toán Chéo hóa (Diagonalization)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### Test Case 1: Normal (Ma trận vuông không đối xứng, các trị riêng phân biệt)\n",
+        "* **Input:**\n",
+        "    $$A = \\begin{pmatrix} 62.5 & -18.2 \\\\ 108.3 & -37.1 \\end{pmatrix}$$\n",
+        "* **Expected Value:**\n",
+        "    * **Trị riêng (Eigenvalues):** $\\lambda_1 \\approx 35.292$, $\\lambda_2 \\approx -9.892$.\n",
+        "    * **Ma trận đường chéo $D$:**\n",
+        "        $$D = \\begin{pmatrix} 35.292 & 0 \\\\ 0 & -9.892 \\end{pmatrix}$$"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "* Kết quả chéo hóa\n",
+            "Ma trận đổi cơ sở P (Các vector riêng nằm trên các cột):\n",
+            "    0.5556   0.2439\n",
+            "    0.8315   0.9698\n",
+            "\n",
+            "Ma trận đường chéo D (Các giá trị riêng):\n",
+            "   35.2606   0.0000\n",
+            "    0.0000  -9.8606\n",
+            "\n",
+            "Ma trận P^-1:\n",
+            "    2.8867  -0.7260\n",
+            "   -2.4750   1.6536\n",
+            "* Kiểm chứng chéo hóa\n",
+            "Sai số tái cấu trúc ||A - P*D*P^-1||max = 4.26e-14\n",
+            "Cài đặt chéo hóa đúng (A ~ P*D*P^-1).\n",
+            "Sai số giá trị riêng so với NumPy = 7.11e-15\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "np.True_"
+            ]
+          },
+          "execution_count": 2,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "demo_diagonalize([\n",
+        "    [62.5, -18.2],\n",
+        "    [108.3, -37.1]\n",
+        "])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### Test Case 2: Boundary (Ma trận đối xứng, trị riêng lặp)giá trị $0$ (ma trận suy biến).\n",
+        "* **Input:**\n",
+        "    $$A = \\begin{pmatrix} 2 & -1 & -1 \\\\ -1 & 2 & -1 \\\\ -1 & -1 & 2 \\end{pmatrix}$$\n",
+        "* **Expected Value:**\n",
+        "    * **Trị riêng:** $\\lambda_1 = 3$, $\\lambda_2 = 3$ (bội 2) và $\\lambda_3 = 0$.\n",
+        "    * **Ma trận đường chéo $D$:**\n",
+        "        $$D = \\begin{pmatrix} 3 & 0 & 0 \\\\ 0 & 3 & 0 \\\\ 0 & 0 & 0 \\end{pmatrix}$$\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "* Kết quả chéo hóa\n",
+            "Ma trận đổi cơ sở P (Các vector riêng nằm trên các cột):\n",
+            "   -0.7071  -0.4082   0.5774\n",
+            "    0.7071  -0.4082   0.5774\n",
+            "    0.0000   0.8165   0.5774\n",
+            "\n",
+            "Ma trận đường chéo D (Các giá trị riêng):\n",
+            "    3.0000   0.0000   0.0000\n",
+            "    0.0000   3.0000   0.0000\n",
+            "    0.0000   0.0000   0.0000\n",
+            "\n",
+            "Ma trận P^-1:\n",
+            "   -0.7071   0.7071  -0.0000\n",
+            "   -0.4082  -0.4082   0.8165\n",
+            "    0.5774   0.5774   0.5774\n",
+            "* Kiểm chứng chéo hóa\n",
+            "Sai số tái cấu trúc ||A - P*D*P^-1||max = 7.49e-13\n",
+            "Cài đặt chéo hóa đúng (A ~ P*D*P^-1).\n",
+            "Sai số giá trị riêng so với NumPy = 7.49e-13\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "np.True_"
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "demo_diagonalize([\n",
+        "    [2.0, -1.0, -1.0],\n",
+        "    [-1.0, 2.0, -1.0],\n",
+        "    [-1.0, -1.0, 2.0]\n",
+        "])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### Test Case 3: Error / Exception (Ma trận khiếm khuyết - Defective Matrix)\n",
+        "* **Input:**\n",
+        "    $$A = \\begin{pmatrix} 5 & 4 & 2 \\\\ 0 & 5 & 1 \\\\ 0 & 0 & 5 \\end{pmatrix}$$\n",
+        "* **Expected Value:**\n",
+        "    * **Trị riêng:** $\\lambda = 5$ (bội 3).\n",
+        "    * **Không gian vector riêng:** Số chiều của không gian vector riêng tương ứng với $\\lambda = 5$ nhỏ hơn 3.\n",
+        "    * Hệ thống phải bắt được ngoại lệ (Exception) hoặc trả về cờ trạng thái `False`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Lỗi: ZeroDivisionError -> division by zero\n"
+          ]
+        }
+      ],
+      "source": [
+        "try:\n",
+        "    demo_diagonalize([\n",
+        "        [5.0, 4.0, 2.0],\n",
+        "        [0.0, 5.0, 1.0],\n",
+        "        [0.0, 0.0, 5.0]\n",
+        "    ])\n",
+        "except Exception as e:\n",
+        "    print(f\"Lỗi: {type(e).__name__} -> {e}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "## 2. Phân rã Giá trị Suy biến (SVD - Singular Value Decomposition)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### Test Case 1: Normal (Ma trận chữ nhật, Full Hạng)\n",
+        "* **Input:**\n",
+        "    $$A = \\begin{pmatrix} 12.5 & 8.2 \\\\ 8.1 & 12.7 \\\\ 8.0 & -8.5 \\end{pmatrix}$$\n",
+        "* **Expected Value:**\n",
+        "    * **Kích thước output:** $U$ là ma trận $3 \\times 3$, $\\Sigma$ là ma trận $3 \\times 2$, và $V^T$ là ma trận $2 \\times 2$.\n",
+        "    * **Giá trị suy biến (Singular Values):** Phải tồn tại 2 giá trị suy biến khác không ($\\sigma_1, \\sigma_2 > 0$) nằm trên đường chéo chính của $\\Sigma$, được sắp xếp giảm dần ($\\sigma_1 \\ge \\sigma_2$)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "* Kết quả phân rã SVD\n",
+            "Ma trận U (Left Singular Vectors):\n",
+            "    0.7009  -0.2754   0.6580\n",
+            "    0.7125   0.2286  -0.6634\n",
+            "   -0.0323  -0.9338  -0.3564\n",
+            "\n",
+            "Ma trận kích thước m x n Sigma (Singular Values):\n",
+            "   20.7579   0.0000\n",
+            "    0.0000  12.4799\n",
+            "    0.0000   0.0000\n",
+            "\n",
+            "Ma trận V^T (Right Singular Vectors Transposed):\n",
+            "    0.6877   0.7260\n",
+            "   -0.7260   0.6877\n",
+            "* Kiểm chứng SVD\n",
+            "Sai số tái cấu trúc ||A - U*Sigma*V^T||max = 1.78e-15\n",
+            "Cài đặt SVD đúng (A ~ U*Sigma*V^T).\n",
+            "Sai số giá trị kỳ dị so với NumPy = 3.55e-15\n"
+          ]
+        }
+      ],
+      "source": [
+        "demo_svd([\n",
+        "    [12.5, 8.2],\n",
+        "    [8.1, 12.7],\n",
+        "    [8.0, -8.5]\n",
+        "])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### Test Case 2: Boundary (Ma trận hạng hụt / Rank-deficient)\n",
+        "* **Input:**\n",
+        "    $$A = \\begin{pmatrix} 2.5 & -5.0 & 7.5 \\\\ 5.0 & -10.0 & 15.0 \\\\ -2.5 & 5.0 & -7.5 \\end{pmatrix}$$\n",
+        "* **Expected Value:**\n",
+        "    * **Hạng của ma trận:** $r = 1$.\n",
+        "    * **Giá trị suy biến:** Chỉ có duy nhất 1 giá trị $\\sigma_1 > 0$. Các giá trị còn lại $\\sigma_2 \\approx 0$ và $\\sigma_3 \\approx 0$."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "* Kết quả phân rã SVD\n",
+            "Ma trận U (Left Singular Vectors):\n",
+            "    0.4082   0.9129  -0.0000\n",
+            "    0.8165  -0.3651   0.4472\n",
+            "   -0.4082   0.1826   0.8944\n",
+            "\n",
+            "Ma trận kích thước m x n Sigma (Singular Values):\n",
+            "   22.9129   0.0000   0.0000\n",
+            "    0.0000   0.0000   0.0000\n",
+            "    0.0000   0.0000   0.0000\n",
+            "\n",
+            "Ma trận V^T (Right Singular Vectors Transposed):\n",
+            "    0.2673  -0.5345   0.8018\n",
+            "    0.8944   0.4472   0.0000\n",
+            "   -0.3586   0.7171   0.5976\n",
+            "* Kiểm chứng SVD\n",
+            "Sai số tái cấu trúc ||A - U*Sigma*V^T||max = 3.55e-15\n",
+            "Cài đặt SVD đúng (A ~ U*Sigma*V^T).\n",
+            "Sai số giá trị kỳ dị so với NumPy = 7.11e-15\n"
+          ]
+        }
+      ],
+      "source": [
+        "demo_svd([\n",
+        "    [2.5, -5.0, 7.5],\n",
+        "    [5.0, -10.0, 15.0],\n",
+        "    [-2.5, 5.0, -7.5]\n",
+        "])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### Test Case 3: Error / Edge (Dữ liệu đầu vào bất hợp lệ)\n",
+        "* **Input:**\n",
+        "    $$A = \\begin{pmatrix} 1.4 & \\text{NaN} \\\\ \\text{Inf} & 3.2 \\end{pmatrix}$$\n",
+        "* **Expected Value:**\n",
+        "    * Hệ thống không được lặp vô hạn hay xử lý ngầm và ra kết quả sai. Bắt buộc phải văng ngoại lệ báo lỗi liên quan đến giá trị bất hợp lệ."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Lỗi: ValueError -> Ma trận chứa giá trị NaN hoặc Inf không hợp lệ.\n"
+          ]
+        }
+      ],
+      "source": [
+        "try:\n",
+        "    demo_svd([\n",
+        "        [1.4, math.nan],\n",
+        "        [math.inf, 3.2]\n",
+        "    ])\n",
+        "except Exception as e:\n",
+        "    print(f\"Lỗi: {type(e).__name__} -> {e}\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.14.3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}


### PR DESCRIPTION
# Part 2 - Chéo hóa ma trận (Diagonalization) & Phân rã giá trị kỳ dị SVD (Singular Value Decomposition)
Cài đặt thuật toán phân rã ma trận và chéo hóa ma trận, kiểm tra thuật toán.

---

### Các hàm đã initialize
Các file được module hóa, trong đó `decomposition.py` tái sử dụng hàm từ `diagonalization.py`.
- **`diagonalization.py`:**
  - **Chính**: `diagonalize(matrix)` trả về bộ ma trận `P, D, PInv`.
  - **Phụ**:
    - `charPoly(matrix)`: Tìm hệ số đa thức đặc trưng bằng thuật toán Faddeev-Leverrier.
    - `findRoots(coeffs)`: Phương pháp lặp Durand-Kerner để tìm các rễ phương trình đa thức đặc trưng.
    - `gaussBasis(matrix, ev)`: Khử Gauss trên $(A - \lambda I)x = 0$ để lấy vector riêng. Chứa logic lập trục (Pivoting).
    - `gaussInverse(matrix)`: Nghịch đảo ma trận Gauss-Jordan. 
- **`decomposition.py`:**
  - **Chính**: `svdDecomp(matA)` hỗ trợ cho mọi ma trận kích thước $m \times n$. Trả về bộ ma trận trực giao và đường chéo `U, Sigma, V^T`.
  - Gọi sử dụng chung các hàm phép toán cơ bản từ file diagonalization: `matrixMultiply`, `matrixTranspose`.

### Ý tưởng chính
- **Chéo hóa (Diagonalization)**: Áp dụng Leverrier-Faddeev tìm phương trình đặc trưng rồi giải nghiệm đa thức bằng phương pháp lặp song song Durand-Kerner. Sau khi có $\lambda$, thuật toán đưa về giải hệ thuần nhất bằng phương pháp Khử Gauss (với *Partial Pivoting* chọn dòng có trị tuyệt đối lớn nhất để khử làm mốc, đảm bảo tránh chia cho 0 và giảm thiểu sai số tính toán).
- **Phân rã SVD**: 
  - Tính $A^T A$, mượn lại hàm `findEigen` bên chéo hóa để lấy các giá trị trị riêng $\lambda_i \ge 0$.
  - Trị kỳ dị $\sigma_i = \sqrt{\lambda_i}$.
  - Tính các cột của $U$ qua công thức $u_i = \frac{A \cdot v_i}{\sigma_i}$.
  - **Lưu ý tính trực giao (Orthogonality) và Liên tục**: Vì hỗ trợ ma trận không vuông $m \times n$, hoăc khi có $\sigma_i = 0$ (Null space), ma trận $U$ có xu hướng bị thiếu cột. Code đã tự động kết hợp chèn chuỗi trực giao hóa **Gram-Schmidt** đối diện với các vector cơ sở gốc (Standard Basis $e_k$) để sinh đủ các cột còn thiếu, giúp ma trận $U$ bảo toàn 100% kích cỡ $m \times m$ và tính chất trực giao vuông góc tuyệt đối.

### Test case
- **Case thường**: Ma trận vuông khả nghịch kích thước chuẩn $n \le 4$, và ma trận chữ nhật $m \times n$ cho mục tiêu phân rã SVD.
- **Case biên/Case lỗi**: 
  - Ma trận suy biến (Defective matrix, $\lambda$ kép hoặc $\sigma_i = 0$). Thuật toán xử lý bằng cách block phân nhánh chặn ngắt ngưỡng `< 1e-9` (phòng chống lỗi *Divide by Zero* khi tính ra $U$).
  - Bổ sung vector giả (zero pivot fallback) trong chéo hóa để chống mảng rỗng.
- **Mức độ verify bằng Thư viện chuẩn**: Cả hai file đều cài đặt logic `verify` tự động đối chiếu norm sai số (max error) với NumPy (`np.linalg.eig` và `np.linalg.svd`). Độ lệch hiện tại được cam kết với ngưỡng rất nhỏ $< 10^{-4}$.

**Chéo hóa**
Ma trận đối xứng:
<img width="967" height="578" alt="image" src="https://github.com/user-attachments/assets/f164c6a8-7d80-4b67-97af-bff35610d536" />
Ma trận bất đối xứng:
<img width="968" height="574" alt="image" src="https://github.com/user-attachments/assets/56c055aa-0f11-4c38-871b-e6db8498b82e" />
Ma trận khiếm khuyết:
<img width="974" height="578" alt="image" src="https://github.com/user-attachments/assets/cdfe6186-fcff-40b2-834d-1a418e0e5cf0" />

**Phân rã SVD**
Ma trận dọc:
<img width="968" height="664" alt="image" src="https://github.com/user-attachments/assets/d32c2566-ffd0-45b8-89aa-dc40c3832f61" />
Ma trận ngang:
<img width="975" height="619" alt="image" src="https://github.com/user-attachments/assets/c1527b2b-7d53-4c5d-99cf-81589e7d80f1" />
Ma trận hạng thiếu (thiếu bậc):
<img width="977" height="690" alt="image" src="https://github.com/user-attachments/assets/aa8c9595-3141-49d9-8adf-d7a30f2e8f32" />

### Thư viện sử dụng
- **core**: Không có thư viện đại số nào được gọi, chỉ thao tác trên Python List gốc `[]`. Sử dụng `math` và `cmath` cho cơ chế cộng/trừ số bậc hai, số phức cơ bản.
- **verify**: Có gọi thư viện `numpy` (cụ thể `np.linalg`), nhưng tất cả chỉ được gói gọn trong vòng hàm `verify()` mục đích nghiệm thu và đối chiếu độ chính xác. Hàm này độc lập và không can thiệp vào quá trình tính toán sinh ra chuỗi Return chính.

### Cần mọi người review
- **Độ phức tạp**: Hàm thực thi tìm điểm nghiệm Durand-Kerner `findRoots` hiện đang fix số bước nhảy là 150 vòng. Điều này hoạt động ưu việt với các ma trận có bậc nhỏ hoặc trung bình ($n \le 4$). Với cấp ma trận cực to ($n > 10$) hoặc độ chênh lệch Eigenvalues cao, method có thể hội tụ chậm và gây sai số.
- **Hiệu năng**: Vì sử dụng ma trận thông qua mảng Python Native hai chiều `[[...]]`, code base chạy chậm hơn khá nhiều so với xử lý C/Fortran của NumPy.
