### PR TITLE
Part2: Diagonalization and Decomposition

### DIFF
--- a/part2/decomposition.py
+++ b/part2/decomposition.py
@@ -1,136 +1,165 @@
+from __future__ import annotations
+
+"""
+PHÂN RÃ GIÁ TRỊ KỲ DỊ (SVD - Singular Value Decomposition)
+Tại sao sử dụng SVD thay vì các loại phân rã khác (LU, QR, Cholesky, Eigen)?
+
+- SVD có thể phân rã MỌI ma trận kích thước m x n bất kỳ (kể cả ma trận chữ nhật hay suy biến).
+- Việc tính toán dựa trên ma trận trực giao giúp SVD không bị lỗi nghiêm trọng khi xử lý ma trận gần suy biến.
+- SVD không chỉ giải hệ, mà còn cô lập các thành phần quan trọng nhất của ma trận thông qua các giá trị kỳ dị lớn.
+"""
+
 import math
+from typing import List, Sequence, Tuple, Union
+
 import numpy as np
-from diagonalization import matrixMultiply, matrixTranspose, findEigen, getColumn
 
-def svdDecomp(matA):
-    # Phân rã SVD cho ma trận m x n: A = U * Sigma * V^T
-    m = len(matA)
-    n = len(matA[0])
-    
-    for row in matA:
-        for val in row:
-            if math.isnan(val) or math.isinf(val):
-                raise ValueError("Ma trận chứa giá trị NaN hoặc Inf không hợp lệ.")
-                
-    # Tính tích A^T * A
-    matATranspose = matrixTranspose(matA)
-    matAtA = matrixMultiply(matATranspose, matA)
-    # Tìm giá trị riêng và vector riêng
-    evs, matV = findEigen(matAtA)
-    # Sắp xếp các giá trị riêng giảm dần kèm theo vector riêng tương ứng
-    evPairs = []
-    for i in range(n):
-        colV = getColumn(matV, i)
-        evPairs.append((evs[i], colV))
-    evPairs.sort(key=lambda x: x[0], reverse=True)
-    
-    ortho_V_cols = []
-    for i in range(n):
-        v = list(evPairs[i][1])
-        for u in ortho_V_cols:
-            dot_uv = sum(x*y for x, y in zip(v, u))
-            v = [x - dot_uv * y for x, y in zip(v, u)]
-        norm = math.sqrt(sum(x*x for x in v))
-        if norm > 1e-9:
-            v = [x/norm for x in v]
-        else:
-            v = [1.0 if j == i else 0.0 for j in range(n)]
-            for u in ortho_V_cols:
-                dot_uv = sum(x*y for x, y in zip(v, u))
-                v = [x - dot_uv * y for x, y in zip(v, u)]
-            norm = math.sqrt(sum(x*x for x in v))
-            if norm > 1e-9: v = [x/norm for x in v]
-        ortho_V_cols.append(v)
-        evPairs[i] = (evPairs[i][0], v)
+from diagonalization import (
+    Matrix,
+    Number,
+    Vector,
+    _EPS,
+    _gram_schmidt,
+    _validate_matrix,
+    find_eigen,
+    get_column,
+    mat_mul,
+    mat_transpose,
+)
 
-    singularVals = []
-    matVSorted = [[0.0 for col in range(n)] for row in range(n)]
-    # Lấy các giá trị kỳ dị bằng căn bậc 2 của các trị riêng dương
-    for i in range(n):
-        val = evPairs[i][0]
-        if val < 1e-9:
-            val = 0.0
-        singularVals.append(math.sqrt(val))
-        for j in range(n):
-            matVSorted[j][i] = evPairs[i][1][j]
-    # Xây dựng ma trận Sigma kích thước m x n
-    matSigma = [[0.0 for col in range(n)] for row in range(m)]
+# ──────────────────────────────────────────────
+
+def svd_decomp(A: Sequence[Sequence[Number]]) -> Tuple[Matrix, Matrix, Matrix]:
+    """
+    Phân rã SVD cho ma trận A (m x n): A = U * Sigma * V^T.
+
+    Đầu vào:
+    - A: ma trận kích thước m x n (không chứa NaN/Inf)
+
+    Đầu ra:
+    - (U, Sigma, V_T): ba ma trận của phân rã SVD
+        * U  : ma trận trực giao kích thước m x m
+        * Sigma: ma trận đường chéo kích thước m x n (các giá trị kỳ dị giảm dần)
+        * V_T: chuyển vị của ma trận trực giao V, kích thước n x n
+    """
+    mat = _validate_matrix(A)
+    m, n = len(mat), len(mat[0])
+
+    At = mat_transpose(mat)
+    AtA = mat_mul(At, mat)
+    evs, matV = find_eigen(AtA)
+
+    raw_cols = sorted(
+        [(evs[i], get_column(matV, i)) for i in range(n)],
+        key=lambda p: p[0], reverse=True,
+    )
+    ortho_V: List[Vector] = _gram_schmidt([list(p[1]) for p in raw_cols])
+    while len(ortho_V) < n:
+        e = [1.0 if j == len(ortho_V) else 0.0 for j in range(n)]
+        ortho_V = _gram_schmidt(ortho_V + [e])
+
+    sigma_vals = [math.sqrt(max(raw_cols[i][0], 0.0)) for i in range(n)]
+
+    V = mat_transpose(ortho_V)
+
+    Sigma: Matrix = [[0.0] * n for _ in range(m)]
     for i in range(min(m, n)):
-        matSigma[i][i] = singularVals[i]
-    # Tạo ma trận U cỡ m x m
-    colsU = []
+        Sigma[i][i] = sigma_vals[i]
+
+    cols_U: List[Vector] = []
     for i in range(min(m, n)):
-        if singularVals[i] > 1e-9:
-            vecI = [[matVSorted[j][i]] for j in range(n)]
-            AVecI = matrixMultiply(matA, vecI)
-            uCol = [AVecI[j][0] / singularVals[i] for j in range(m)]
-            colsU.append(uCol)
+        if sigma_vals[i] > _EPS:
+            vi = [[V[j][i]] for j in range(n)]
+            Avi = mat_mul(mat, vi)
+            cols_U.append([Avi[j][0] / sigma_vals[i] for j in range(m)])
+
     for i in range(m):
-        if len(colsU) == m:
+        if len(cols_U) >= m:
             break
-        tempV = [0.0] * m
-        tempV[i] = 1.0
-        for existU in colsU:
-            dotProd = sum([tempV[k] * existU[k] for k in range(m)])
-            for k in range(m):
-                tempV[k] -= dotProd * existU[k]
-        norm = math.sqrt(sum([val**2 for val in tempV]))
-        if norm > 1e-9:
-            newU = [tempV[k] / norm for k in range(m)]
-            colsU.append(newU)
-    matU = matrixTranspose(colsU)
-    matVTranspose = matrixTranspose(matVSorted)
-    return matU, matSigma, matVTranspose
+        e = [1.0 if j == i else 0.0 for j in range(m)]
+        extended = _gram_schmidt(cols_U + [e])
+        if len(extended) > len(cols_U):
+            cols_U = extended
 
-def verifySvd(matA, matU, matSigma, matVT):
-    arrA = np.array(matA, dtype=float)
-    arrU = np.array(matU, dtype=float)
-    arrSigma = np.array(matSigma, dtype=float)
-    arrVT = np.array(matVT, dtype=float)
-    arrRebuilt = arrU @ arrSigma @ arrVT
-    maxError = np.max(np.abs(arrA - arrRebuilt))
+    U = mat_transpose(cols_U)
+    V_T = mat_transpose(V)
+
+    return U, Sigma, V_T
+
+# ──────────────────────────────────────────────
+
+def verify_svd(
+    A: Matrix,
+    U: Matrix,
+    Sigma: Matrix,
+    V_T: Matrix,
+) -> bool:
+    """
+    Kiểm chứng kết quả phân rã SVD: tính sai số ||A - U*Sigma*V^T||max và so sánh
+    giá trị kỳ dị với NumPy.
+
+    Đầu vào:
+    - A: ma trận gốc kích thước m x n
+    - U: ma trận trái kích thước m x m
+    - Sigma: ma trận đường chéo kích thước m x n
+    - V_T: chuyển vị ma trận phải kích thước n x n
+
+    Đầu ra:
+    - True nếu cả hai sai số nhỏ hơn 1e-4, ngược lại False
+    """
+    arrA = np.array(A, dtype=float)
+    rebuilt = np.array(U) @ np.array(Sigma) @ np.array(V_T)
+    err_recon = float(np.max(np.abs(arrA - rebuilt)))
     print("* Kiểm chứng SVD")
-    print(f"Sai số tái cấu trúc ||A - U*Sigma*V^T||max = {maxError:.2e}")
-    if maxError < 1e-4:
-        print("Cài đặt SVD đúng (A ~ U*Sigma*V^T).")
-    else:
-        print("Cài đặt SVD có thể có sai số cao.")
-    arrS = np.linalg.svd(arrA)[1]
-    # So sánh các giá trị kỳ dị (chỉ lưu min(m, n) phần tử)
-    mySingularVals = [matSigma[i][i] for i in range(min(len(matA), len(matA[0])))]
-    errSv = np.max(np.abs(np.array(mySingularVals) - arrS))
-    print(f"Sai số giá trị kỳ dị so với NumPy = {errSv:.2e}")
-    return maxError < 1e-4 and errSv < 1e-4
+    print(f"Sai số tái cấu trúc ||A - U*Sigma*V^T||max = {err_recon:.2e}")
+    print("Cài đặt SVD đúng (A ~ U*Sigma*V^T)." if err_recon < 1e-4
+          else "Cài đặt SVD có thể có sai số cao.")
 
-def demo_svd(matA):
-    matU, matSigma, matVT = svdDecomp(matA)
+    np_svs = np.linalg.svd(arrA, compute_uv=False)
+    my_svs = np.array([Sigma[i][i] for i in range(min(len(A), len(A[0])))])
+    err_sv = float(np.max(np.abs(my_svs - np_svs)))
+    print(f"Sai số giá trị kỳ dị so với NumPy = {err_sv:.2e}")
+    return err_recon < 1e-4 and err_sv < 1e-4
+
+def demo_svd(A: Sequence[Sequence[Number]]) -> None:
+    """
+    Thực hiện phân rã SVD cho ma trận A và in kết quả ra màn hình.
+
+    Đầu vào:
+    - A: ma trận kích thước m x n
+    """
+    mat = _validate_matrix(A)
+    U, Sigma, V_T = svd_decomp(mat)
     print("\n* Kết quả phân rã SVD")
-    print("Ma trận U (Left Singular Vectors):")
-    for row in matU:
-        print("  " + " ".join(f"{val:8.4f}" for val in row))
-    print("\nMa trận kích thước m x n Sigma (Singular Values):")
-    for row in matSigma:
-        print("  " + " ".join(f"{val:8.4f}" for val in row))
-    print("\nMa trận V^T (Right Singular Vectors Transposed):")
-    for row in matVT:
-        print("  " + " ".join(f"{val:8.4f}" for val in row))
-    verifySvd(matA, matU, matSigma, matVT)
+    print("Ma trận U:")
+    for row in U:
+        print("  " + " ".join(f"{v:8.4f}" for v in row))
+    print("\nMa trận Sigma:")
+    for row in Sigma:
+        print("  " + " ".join(f"{v:8.4f}" for v in row))
+    print("\nMa trận V^T:")
+    for row in V_T:
+        print("  " + " ".join(f"{v:8.4f}" for v in row))
+    verify_svd(mat, U, Sigma, V_T)
 
-def main():
+# ──────────────────────────────────────────────
+
+def main() -> None:
     try:
-        rows = int(input("Nhập số dòng m = "))
-        cols = int(input("Nhập số cột n = "))
-        print(f"Nhập ma trận {rows}x{cols} (mỗi dòng cách nhau bởi dấu Enter, các phần tử cách nhau bởi khoảng trắng):")
-        matA = []
-        for i in range(rows):
+        rows_n = int(input("Nhập số dòng m = "))
+        cols_n = int(input("Nhập số cột n = "))
+        print(f"Nhập ma trận {rows_n}x{cols_n} (mỗi dòng cách nhau bởi dấu Enter, "
+              "các phần tử cách nhau bởi khoảng trắng):")
+        mat: Matrix = []
+        for i in range(rows_n):
             row = list(map(float, input().strip().split()))
-            if len(row) != cols:
-                print(f"Lỗi: Dòng {i+1} không có đủ {cols} phần tử. Vui lòng thử lại.")
-                exit()
-            matA.append(row)
-        demo_svd(matA)
-    except ValueError:
-        print("Lỗi: Dữ liệu nhập vào chưa hợp lệ.")
+            if len(row) != cols_n:
+                print(f"Lỗi: Dòng {i + 1} không có đủ {cols_n} phần tử.")
+                return
+            mat.append(row)
+        demo_svd(mat)
+    except ValueError as e:
+        print(f"Lỗi: {e}")
 
 if __name__ == "__main__":
     main()

--- a/part2/diagonalization.py
+++ b/part2/diagonalization.py
@@ -1,295 +1,391 @@
-import math
-import numpy as np
+from __future__ import annotations
+
 import cmath
+import math
+from typing import List, Sequence, Tuple, Union
 
-def getColumn(matrix, colIndex):
-    return [row[colIndex] for row in matrix]
+import numpy as np
 
-def matrixMultiply(matA, matB):
-    rowsA = len(matA)
-    colsA = len(matA[0])
-    colsB = len(matB[0])
-    result = [[0.0 for col in range(colsB)] for row in range(rowsA)]
-    for i in range(rowsA):
-        for j in range(colsB):
-            sumProd = 0.0
-            for k in range(colsA):
-                sumProd += matA[i][k] * matB[k][j]
-            result[i][j] = sumProd
-    return result
+import os
+import sys
 
-def matrixTranspose(matrix):
-    rows = len(matrix)
-    cols = len(matrix[0])
-    result = [[0.0 for row in range(rows)] for col in range(cols)]
-    for i in range(rows):
-        for j in range(cols):
-            result[j][i] = matrix[i][j]
-    return result
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from part1.inverse import inverse
+from part1.rank_basis import rank_and_basis
 
-def gaussInverse(matrix):
-    n = len(matrix)
-    augMat = [row[:] + [1.0 if i == j else 0.0 for j in range(n)] for i, row in enumerate(matrix)]
-    for i in range(n):
-        pivot = augMat[i][i]
-        if abs(pivot) < 1e-9:
-            for k in range(i + 1, n):
-                if abs(augMat[k][i]) > abs(pivot):
-                    augMat[i], augMat[k] = augMat[k], augMat[i]
-                    pivot = augMat[i][i]
-                    break
-        for j in range(2 * n):
-            augMat[i][j] /= pivot
-        for k in range(n):
-            if k != i:
-                factor = augMat[k][i]
-                for j in range(2 * n):
-                    augMat[k][j] -= factor * augMat[i][j]
-    return [row[n:] for row in augMat]
+Number = Union[int, float]
+Matrix = List[List[float]]
+Vector = List[float]
 
-def charPoly(matrix):
-    # Trả về mảng hệ số đa thức đặc trưng [cn, c(n-1), ..., c0]
-    n = len(matrix)
+_EPS = 1e-9
+
+# ──────────────────────────────────────────────
+
+def _copy(M: Matrix) -> Matrix:
+    """
+    Tạo bản sao của ma trận M.
+
+    Đầu vào:
+    - M: ma trận đầu vào
+
+    Đầu ra:
+    - bản sao của ma trận M
+    """
+    return [row[:] for row in M]
+
+def _identity(n: int) -> Matrix:
+    """
+    Tạo ma trận đơn vị kích thước n x n.
+
+    Đầu vào:
+    - n: kích thước ma trận
+
+    Đầu ra:
+    - ma trận đơn vị kích thước n x n
+    """
+    return [[1.0 if i == j else 0.0 for j in range(n)] for i in range(n)]
+
+def get_column(M: Matrix, col: int) -> Vector:
+    """
+    Trả về cột thứ `col` của ma trận M.
+
+    Đầu vào:
+    - M: ma trận kích thước m x n
+    - col: chỉ số cột
+
+    Đầu ra:
+    - vector cột dưới dạng list
+    """
+    return [row[col] for row in M]
+
+def mat_mul(A: Matrix, B: Matrix) -> Matrix:
+    """
+    Nhân hai ma trận A (m x k) và B (k x n).
+
+    Đầu vào:
+    - A: ma trận kích thước m x k
+    - B: ma trận kích thước k x n
+
+    Đầu ra:
+    - ma trận tích kích thước m x n
+    """
+    m, k, n = len(A), len(A[0]), len(B[0])
+    return [
+        [sum(A[i][t] * B[t][j] for t in range(k)) for j in range(n)]
+        for i in range(m)
+    ]
+
+def mat_transpose(M: Matrix) -> Matrix:
+    """
+    Chuyển vị ma trận M (m x n) thành ma trận n x m.
+
+    Đầu vào:
+    - M: ma trận kích thước m x n
+
+    Đầu ra:
+    - ma trận chuyển vị kích thước n x m
+    """
+    m, n = len(M), len(M[0])
+    return [[M[i][j] for i in range(m)] for j in range(n)]
+
+def _validate_matrix(M: Sequence[Sequence[Number]], label: str = "Ma trận") -> Matrix:
+    """
+    Kiểm tra và chuyển đổi ma trận đầu vào về dạng chuẩn.
+
+    Đầu vào:
+    - M: ma trận đầu vào
+    - label: nhãn ma trận
+
+    Đầu ra:
+    - ma trận chuẩn
+    """
+    if not M:
+        raise ValueError(f"{label} không được rỗng.")
+    mat = [list(map(float, row)) for row in M]
+    ncols = len(mat[0])
+    if ncols == 0:
+        raise ValueError(f"{label} phải có ít nhất một cột.")
+    if any(len(row) != ncols for row in mat):
+        raise ValueError(f"{label} phải là ma trận hình chữ nhật.")
+    for row in mat:
+        for v in row:
+            if math.isnan(v) or math.isinf(v):
+                raise ValueError(f"{label} chứa giá trị NaN hoặc Inf không hợp lệ.")
+    return mat
+
+# ──────────────────────────────────────────────
+
+def gauss_inverse(M: Matrix) -> Matrix:
+    try:
+        return inverse(M, eps=_EPS)
+    except ValueError as e:
+        raise ValueError("Ma trận suy biến, không tồn tại ma trận nghịch đảo.") from e
+
+# ──────────────────────────────────────────────
+
+def char_poly(M: Matrix) -> List[float]:
+    """
+    Tính các hệ số đa thức đặc trưng của ma trận M bằng thuật toán Faddeev-LeVerrier.
+
+    Đầu vào:
+    - M: ma trận vuông kích thước n x n
+
+    Đầu ra:
+    - list hệ số [c_n, c_{n-1}, ..., c_0]
+    """
+    n = len(M)
     c = [1.0]
-    matB = [[1.0 if i == j else 0.0 for j in range(n)] for i in range(n)]
+    B = _identity(n)
     for k in range(1, n + 1):
-        if k == 1:
-            matM = matrix
-        else:
-            matM = matrixMultiply(matrix, matB)
-        traceM = sum(matM[i][i] for i in range(n))
-        ak = - traceM / k
+        MB = [row[:] for row in M] if k == 1 else mat_mul(M, B)
+        trace = sum(MB[i][i] for i in range(n))
+        ak = -trace / k
         c.append(ak)
-        matB = [[matM[i][j] + (ak if i == j else 0.0) for j in range(n)] for i in range(n)]
+        B = [[MB[i][j] + (ak if i == j else 0.0) for j in range(n)] for i in range(n)]
     return c
 
-def findRoots(coeffs):
-    # Tìm các rễ phương trình đa thức đặc trưng
+def find_roots(coeffs: List[float]) -> List[float]:
+    """
+    Tìm nghiệm thực của đa thức bằng phương pháp Durand-Kerner.
+
+    Đầu vào:
+    - coeffs: list hệ số [c_n, c_{n-1}, ..., c_0]
+
+    Đầu ra:
+    - list các nghiệm thực
+    """
     n = len(coeffs) - 1
     roots = [cmath.rect(1.5, 2 * math.pi * k / n) for k in range(n)]
-    for step in range(150):
+    for _ in range(200):
         for k in range(n):
-            polyVal = 0.0
-            for j in range(n + 1):
-                polyVal += coeffs[j] * (roots[k] ** (n - j))
-            den = 1.0
+            p_val = sum(coeffs[j] * roots[k] ** (n - j) for j in range(n + 1))
+            denom = 1.0
             for j in range(n):
                 if j != k:
-                    den *= (roots[k] - roots[j])
-            if abs(den) > 1e-15:
-                roots[k] -= polyVal / den
-    return [float(x.real) for x in roots if abs(x.imag) < 1e-3]
+                    denom *= roots[k] - roots[j]
+            if abs(denom) > 1e-15:
+                roots[k] -= p_val / denom
+    return [float(r.real) for r in roots if abs(r.imag) < 1e-3]
 
-def gaussBasis(matrix, ev):
-    # Cài đặt thuật toán khử Gauss trên (A - lambda * I)x = 0 để lấy không gian nghiệm
-    n = len(matrix)
-    aug = [[matrix[i][j] - (ev if i == j else 0.0) for j in range(n)] for i in range(n)]
+# ──────────────────────────────────────────────
+
+def _gram_schmidt(vectors: List[Vector]) -> List[Vector]:
+    """Trực chuẩn hóa danh sách vector bằng Gram-Schmidt."""
+    ortho: List[Vector] = []
+    for v in vectors:
+        for u in ortho:
+            dot = sum(x * y for x, y in zip(v, u))
+            v = [x - dot * y for x, y in zip(v, u)]
+        norm = math.sqrt(sum(x * x for x in v))
+        if norm > _EPS:
+            ortho.append([x / norm for x in v])
+    return ortho
+
+def eigenspace_basis(M: Matrix, eigenvalue: float) -> List[Vector]:
+    """
+    Tìm cơ sở trực chuẩn của không gian riêng (M - lambda*I)x = 0.
+
+    Đầu vào:
+    - M: ma trận vuông kích thước n x n
+    - eigenvalue: giá trị riêng lambda
+
+    - list các vector cơ sở trực chuẩn của không gian riêng tương ứng
+    """
+    n = len(M)
+    shifted = [[M[i][j] - (eigenvalue if i == j else 0.0) for j in range(n)] for i in range(n)]
     
-    lead = 0
-    pivotCols = []
-    pivotRows = []
-    r = 0
-    while r < n and lead < n:
-        maxVal = 0.0
-        maxIdx = r
-        for i in range(r, n):
-            if abs(aug[i][lead]) > maxVal:
-                maxVal = abs(aug[i][lead])
-                maxIdx = i
-        if maxVal < 1e-6:
-            lead += 1
-            continue
-        aug[maxIdx], aug[r] = aug[r], aug[maxIdx]
-        pivotCols.append(lead)
-        pivotRows.append(r)
-        lv = aug[r][lead]
-        for j in range(n):
-            aug[r][j] /= lv
-        for i in range(n):
-            if i != r:
-                lv = aug[i][lead]
-                for j in range(n):
-                    aug[i][j] -= lv * aug[r][j]
-        r += 1
-        lead += 1
-        
-    freeCols = [j for j in range(n) if j not in pivotCols]
-    if not freeCols:
-        if pivotCols:
-            pivotCols.pop()
-            pivotRows.pop()
-        freeCols.append(n - 1)
-        
-    basis = []
-    for f in freeCols:
+    info = rank_and_basis(shifted, eps=1e-4)
+    basis = info["null_space_basis"]
+
+    if not basis:
+        rref = info["rref"]
         v = [0.0] * n
-        v[f] = 1.0
-        for i, pCol in enumerate(pivotCols):
-            rIdx = pivotRows[i]
-            v[pCol] = -aug[rIdx][f]
+        v[-1] = 1.0
+        for pr, pc in enumerate(info["pivot_columns"][:-1]):
+            if pr < len(rref):
+                v[pc] = -rref[pr][-1]
         basis.append(v)
-        
-    ortho_basis = []
-    for v in basis:
-        for u in ortho_basis:
-            dot_uv = sum(x*y for x, y in zip(v, u))
-            v = [x - dot_uv * y for x, y in zip(v, u)]
-        norm = math.sqrt(sum(x*x for x in v))
-        if norm > 1e-9:
-            v = [x/norm for x in v]
-            ortho_basis.append(v)
-            
-    while len(ortho_basis) < len(freeCols):
-        extraV = [0.0] * n
-        for i in range(n):
-            extraV[i] = 1.0 if len(ortho_basis) == i else 0.0
-        for u in ortho_basis:
-            dot_uv = sum(x*y for x, y in zip(extraV, u))
-            extraV = [x - dot_uv * y for x, y in zip(extraV, u)]
-        norm = math.sqrt(sum(x*x for x in extraV))
-        if norm > 1e-9:
-            extraV = [x/norm for x in extraV]
-            ortho_basis.append(extraV)
-            
-    return ortho_basis
 
-def findEigen(matrix):
-    # Detect bậc
-    n = len(matrix)
-    if n <= 4:
-        # Bậc <= 4: Dùng khử Gauss
-        coeffs = charPoly(matrix)
-        evs = findRoots(coeffs)
-        evs.sort(reverse=True)
-        uniqueEvs = []
-        for ev in evs:
-            if not any(abs(ev - u) < 1e-4 for u in uniqueEvs):
-                uniqueEvs.append(ev)  
-        finalEvs = []
-        pRows = []
-        for ev in uniqueEvs:
-            basis = gaussBasis(matrix, ev)
-            for vec in basis:
-                finalEvs.append(ev)
-                pRows.append(vec)
-        # Phân phối và giới hạn lại số chiều vector tương ứng bậc N
-        sortedPairs = sorted(zip(finalEvs, pRows), key=lambda x: x[0], reverse=True)
-        sortedEvs = [p[0] for p in sortedPairs][:n]
-        sortedVecs = [p[1] for p in sortedPairs][:n]
-        # Bổ sung vector fallback cho tình trạng zero pivot array loss
-        while len(sortedEvs) < n:
-            sortedEvs.append(0.0)
-            extraV = [0.0] * n
-            extraV[len(sortedEvs) - 1] = 1.0
-            sortedVecs.append(extraV)
-        return sortedEvs, matrixTranspose(sortedVecs)
-    else:
-        # Bậc > 4: Dùng thư viện numpy.linalg.eig
-        arrM = np.array(matrix, dtype=float)
-        npEvs, npEvecs = np.linalg.eig(arrM)
-        npEvs = npEvs.real
-        npEvecs = npEvecs.real
-        # Sắp xếp giảm dần để đồng nhất
-        idx = np.argsort(npEvs)[::-1]
-        npEvs = npEvs[idx]
-        npEvecs = npEvecs[:, idx]
-        return npEvs.tolist(), npEvecs.tolist()
+    return _gram_schmidt(basis)
 
-def checkDiagonalizable(evs, matP):
-    n = len(evs)
-    distinct = True
+# ──────────────────────────────────────────────
+
+def find_eigen(M: Matrix) -> Tuple[List[float], Matrix]:
+    """
+    Tìm giá trị riêng và ma trận vector riêng của ma trận vuông M.
+
+    Đầu vào:
+    - M: ma trận vuông kích thước n x n
+
+    Đầu ra:
+    - (eigenvalues, P): list giá trị riêng sắp xếp giảm dần và ma trận P
+      gồm các cột là vector riêng tương ứng
+    """
+    n = len(M)
+
+    is_diag = True
     for i in range(n):
-        for j in range(i + 1, n):
-            if abs(evs[i] - evs[j]) < 1e-4:
-                distinct = False
+        for j in range(n):
+            if i != j and abs(M[i][j]) > _EPS:
+                is_diag = False
                 break
-        if not distinct:
+        if not is_diag:
             break
-    if distinct:
-        return True, "Ma trận thỏa mãn điều kiện đủ: Có n giá trị riêng phân biệt."
-    # Điều kiện cần và đủ: A có n vector riêng độc lập tuyến tính
-    mat = [row[:] for row in matP]
-    for i in range(n):
-        pivot = mat[i][i]
-        if abs(pivot) < 1e-9:
-            for k in range(i + 1, n):
-                if abs(mat[k][i]) > abs(pivot):
-                    mat[i], mat[k] = mat[k], mat[i]
-                    pivot = mat[i][i]
-                    break
-        if abs(pivot) < 1e-9:
-            return False, "Ma trận không chéo hóa được: Không đủ n vector riêng độc lập tuyến tính."
-        for k in range(i + 1, n):
-            factor = mat[k][i] / pivot
-            for j in range(i, n):
-                mat[k][j] -= factor * mat[i][j]
-                
-    return True
 
-def diagonalize(matrix):
-    # Chéo hóa ma trận thành A = P * D * P^-1
-    n = len(matrix)
-    evs, matP = findEigen(matrix)
-    matD = [[0.0 for col in range(n)] for row in range(n)]
-    for i in range(n):
-        matD[i][i] = evs[i]  
-        
-    is_diag = checkDiagonalizable(evs, matP)
-    
-    if not is_diag:
-        raise ValueError("Lỗi: Ma trận không thể chéo hóa được do không thỏa điều kiện.")
-        
-    matPInv = gaussInverse(matP)
-    return matP, matD, matPInv
+    if is_diag:
+        return [float(M[i][i]) for i in range(n)], _identity(n)
 
-def verify(matrixA, matP, matD, matPInv):
-    # Sử dụng Numpy để đổi trọng số sai số
-    arrA = np.array(matrixA, dtype=float)
-    arrP = np.array(matP, dtype=float)
-    arrD = np.array(matD, dtype=float)
-    arrPInv = np.array(matPInv, dtype=float)
-    arrRebuilt = arrP @ arrD @ arrPInv
-    maxError = np.max(np.abs(arrA - arrRebuilt))
-    print("* Kiểm chứng chéo hóa")
-    print(f"Sai số tái cấu trúc ||A - P*D*P^-1||max = {maxError:.2e}")
-    if maxError < 1e-4:
-        print("Cài đặt chéo hóa đúng (A ~ P*D*P^-1).")
+    if n <= 4:
+        coeffs = char_poly(M)
+        raw_evs = find_roots(coeffs)
+        raw_evs.sort(reverse=True)
+
+        unique_evs: List[float] = []
+        for ev in raw_evs:
+            if not any(abs(ev - u) < 1e-4 for u in unique_evs):
+                unique_evs.append(ev)
+
+        ev_list: List[float] = []
+        vec_list: List[Vector] = []
+        for ev in unique_evs:
+            for vec in eigenspace_basis(M, ev):
+                ev_list.append(ev)
+                vec_list.append(vec)
+
+        pairs = sorted(zip(ev_list, vec_list), key=lambda p: p[0], reverse=True)[:n]
+        ev_list = [p[0] for p in pairs]
+        vec_list = [p[1] for p in pairs]
+
+        while len(ev_list) < n:
+            ev_list.append(ev_list[0] if ev_list else 0.0)
+            vec_list.append([0.0] * n)
+
+        return ev_list, mat_transpose(vec_list)
     else:
-        print("Cài đặt chéo hóa có thể có sai số cao.")   
-    arrEvs = np.linalg.eigvals(arrA)
-    myEvs = np.diag(arrD)
-    errEv = np.max(np.abs(np.sort(myEvs)[::-1] - np.sort(arrEvs.real)[::-1]))
-    print(f"Sai số giá trị riêng so với NumPy = {errEv:.2e}")
-    return maxError < 1e-4 and errEv < 1e-4
+        arr = np.array(M, dtype=float)
+        vals, vecs = np.linalg.eig(arr)
+        vals, vecs = vals.real, vecs.real
+        idx = np.argsort(vals)[::-1]
+        return vals[idx].tolist(), vecs[:, idx].tolist()
 
-def demo_diagonalize(matA):
-    matP, matD, matPInv = diagonalize(matA)
+# ──────────────────────────────────────────────
+
+def check_diagonalizable(evs: List[float], P: Matrix) -> Tuple[bool, str]:
+    """
+    Kiểm tra ma trận có chéo hóa được không dựa vào ma trận vector riêng P.
+
+    Đầu vào:
+    - evs: list giá trị riêng
+    - P: ma trận vector riêng (các cột là vector riêng)
+
+    Đầu ra:
+    - (is_diag, message): True nếu chéo hóa được, kèm thông báo giải thích
+    """
+    n = len(evs)
+    if all(abs(evs[i] - evs[j]) > 1e-4 for i in range(n) for j in range(i + 1, n)):
+        return True, "Ma trận thỏa mãn điều kiện đủ: Có n giá trị riêng phân biệt."
+
+    info = rank_and_basis(P, eps=_EPS)
+    if info["rank"] == n:
+        return True, "Ma trận có đủ n vector riêng độc lập tuyến tính."
+    return False, "Ma trận không chéo hóa được: Không đủ n vector riêng độc lập tuyến tính."
+
+def diagonalize(A: Sequence[Sequence[Number]]) -> Tuple[Matrix, Matrix, Matrix]:
+    """
+    Chéo hóa ma trận A thành dạng A = P * D * P^-1.
+
+    Đầu vào:
+    - A: ma trận vuông kích thước n x n
+
+    Đầu ra:
+    - (P, D, P_inv): ma trận đổi cơ sở, ma trận đường chéo và nghịch đảo của P
+    """
+    mat = _validate_matrix(A)
+    n = len(mat)
+    if len(mat[0]) != n:
+        raise ValueError("Ma trận phải là ma trận vuông.")
+
+    evs, P = find_eigen(mat)
+    D = [[evs[i] if i == j else 0.0 for j in range(n)] for i in range(n)]
+
+    ok, msg = check_diagonalizable(evs, P)
+    if not ok:
+        raise ValueError(f"Lỗi: {msg}")
+
+    P_inv = gauss_inverse(P)
+    return P, D, P_inv
+
+# ──────────────────────────────────────────────
+
+def verify(A: Matrix, P: Matrix, D: Matrix, P_inv: Matrix) -> bool:
+    """
+    Kiểm chứng kết quả chéo hóa: tính sai số ||A - P*D*P^-1||max và so sánh giá trị
+    riêng với NumPy.
+
+    Đầu vào:
+    - A: ma trận gốc
+    - P: ma trận đổi cơ sở
+    - D: ma trận đường chéo
+    - P_inv: nghịch đảo của P
+
+    Đầu ra:
+    - True nếu cả hai sai số nhỏ hơn 1e-4, ngược lại False
+    """
+    arrA = np.array(A, dtype=float)
+    rebuilt = np.array(P) @ np.array(D) @ np.array(P_inv)
+    err_recon = float(np.max(np.abs(arrA - rebuilt)))
+    print("* Kiểm chứng chéo hóa")
+    print(f"Sai số tái cấu trúc ||A - P*D*P^-1||max = {err_recon:.2e}")
+    print("Cài đặt chéo hóa đúng (A ~ P*D*P^-1)." if err_recon < 1e-4
+          else "Cài đặt chéo hóa có thể có sai số cao.")
+
+    np_evs = np.sort(np.linalg.eigvals(arrA).real)[::-1]
+    my_evs = np.sort(np.diag(np.array(D)))[::-1]
+    err_ev = float(np.max(np.abs(my_evs - np_evs)))
+    print(f"Sai số giá trị riêng so với NumPy = {err_ev:.2e}")
+    return err_recon < 1e-4 and err_ev < 1e-4
+
+def demo_diagonalize(A: Sequence[Sequence[Number]]) -> bool:
+    """
+    Thực hiện chéo hóa ma trận A và in kết quả ra màn hình.
+
+    Đầu vào:
+    - A: ma trận vuông kích thước n x n
+
+    Đầu ra:
+    - True nếu kết quả chéo hóa đúng (sai số nhỏ hơn ngưỡng), ngược lại False
+    """
+    P, D, P_inv = diagonalize(A)
+    mat = _validate_matrix(A)
     print("\n* Kết quả chéo hóa")
-    print("Ma trận đổi cơ sở P (Các vector riêng nằm trên các cột):")
-    for row in matP:
-        print("  " + " ".join(f"{val:8.4f}" for val in row))
-    print("\nMa trận đường chéo D (Các giá trị riêng):")
-    for row in matD:
-        print("  " + " ".join(f"{val:8.4f}" for val in row))
+    print("Ma trận đổi cơ sở P:")
+    for row in P:
+        print("  " + " ".join(f"{v:8.4f}" for v in row))
+    print("\nMa trận đường chéo D:")
+    for row in D:
+        print("  " + " ".join(f"{v:8.4f}" for v in row))
     print("\nMa trận P^-1:")
-    for row in matPInv:
-        print("  " + " ".join(f"{val:8.4f}" for val in row))
-    return verify(matA, matP, matD, matPInv)
+    for row in P_inv:
+        print("  " + " ".join(f"{v:8.4f}" for v in row))
+    return verify(mat, P, D, P_inv)
 
-def main():
+# ──────────────────────────────────────────────
+
+def main() -> None:
     try:
         size = int(input("Nhập kích thước ma trận vuông n = "))
-        print(f"Nhập ma trận {size}x{size} (mỗi dòng cách nhau bởi dấu Enter, các phần tử cách nhau bởi khoảng trắng):")
-        matA = []
+        print(f"Nhập ma trận {size}x{size} (mỗi dòng cách nhau bởi dấu Enter, "
+              "các phần tử cách nhau bởi khoảng trắng):")
+        rows = []
         for i in range(size):
             row = list(map(float, input().strip().split()))
             if len(row) != size:
-                print(f"Lỗi: Dòng {i+1} không có đủ {size} phần tử. Vui lòng thử lại.")
-                exit()
-            matA.append(row)
-        demo_diagonalize(matA)
-    except ValueError:
-        print("Lỗi: Dữ liệu nhập vào chưa hợp lệ.")
+                print(f"Lỗi: Dòng {i + 1} không có đủ {size} phần tử.")
+                return
+            rows.append(row)
+        demo_diagonalize(rows)
+    except ValueError as e:
+        print(f"Lỗi: {e}")
 
 if __name__ == "__main__":
     main()

--- a/part2/readme.md
+++ b/part2/readme.md
@@ -1,0 +1,62 @@
+# Phần 2: Chéo hóa & Phân rã Ma trận SVD
+
+Xây dựng các hàm để **Chéo hóa ma trận** và **Phân rã giá trị kỳ dị (SVD)**. Sử dụng `numpy` ở phân hệ đánh giá, kiểm chứng sai số.
+
+## 1. Cấu trúc thư mục
+
+```text
+part2/
+│
+├── diagonalization.py
+├── decomposition.py
+├── test.ipynb
+└── readme.md
+```
+
+## 2. Chi tiết Thuật toán áp dụng
+
+### A. Chéo Hóa Ma Trận (`diagonalization.py`)
+Mục tiêu bài toán là biểu diễn ma trận vuông $A$ thành $A = P \cdot D \cdot P^{-1}$.
+Các kỹ thuật tích hợp:
+- Tính đa thức đặc trưng: Nhận hệ số $c_n, c_{n-1}, ...$ ổn định từ ma trận $A$ bằng thuật toán Faddeev-LeVerrier.
+- Tìm trị riêng: Triển khai phương pháp lặp song song Durand-Kerner trên không gian số phức để tìm nghiệm đa thức.
+- Tìm vector riêng: Tái sử dụng thuật toán Khử Gauss-Jordan của *phần 1 (`part1.rank_basis`)*. Từ đó tìm ra các cơ sở cho dòng suy biến.
+- Trực chuẩn hoá (Gram-Schmidt): Đảm bảo các vector riêng độc lập tuyến tính và ở dạng trực chuẩn (orthonormal).
+- Fallback: Áp dụng các thuật toán gốc rễ trên cho ma trận có kích thước $n \le 4$. Kích thước lớn hơn sẽ được fallback nhường vị trí cho thư viện tính toán lớn để đảm bảo tốc độ. Báo `ValueError` chống lỗi nghiêm trọng đối với các ma trận khuyết.
+
+### B. Phân rã SVD (`decomposition.py`)
+SVD là ma trận giải quyết bài toán biểu diễn: $A = U \cdot \Sigma \cdot V^T$.
+Đặc tính vượt trội:
+- Hỗ trợ mọi ma trận: Kể cả trường hợp $M \times N$ hình chữ nhật, ma trận hạng hụt (rank-deficient).
+- Logic trích xuất:
+  1. Xây dựng $A^T \cdot A$ (luôn đối xứng).
+  2. Tái sử dụng module chéo hóa phía trên để nới giá trị riêng và vector riêng $\rightarrow$ trực tiếp suy ra ma trận đường chéo $\Sigma$ và ma trận $V$.
+  3. Hoàn thiện $U$ bằng $A \cdot v_i / \sigma_i$.
+  4. Bổ khuyết không gian null của $U$ (nếu thiếu dòng) bằng **Trực chuẩn hóa Gram-Schmidt** để duy trì tính chất $U^T \cdot U = I$.
+
+---
+
+## 3. Hướng dẫn kiểm thử
+
+Mã nguồn được thiết kế với giao diện cho phép nhập liệu ma trận trực tiếp từ terminal.
+
+### 3.1. Chạy demo qua terminal
+Kiểm duyệt song song theo thời gian thực với NumPy. Sai số tái cấu trúc yêu cầu ở ngưỡng $< 10^{-4}$.
+
+*Chạy tính toán Chéo hóa:*
+```python
+python part2/diagonalization.py
+```
+
+*Chạy tính toán SVD:*
+```python
+python part2/decomposition.py
+```
+
+### 3.2. Test bằng notebook (`test.ipynb`)
+Bao gồm 10 Test Cases (5 cho Chéo hoá, 5 cho SVD):
+- Trị riêng phân biệt, trị riêng lặp.
+- Ma trận chữ nhật dư dòng, dư cột.
+- Ma trận suy biến, khuyết hệ số, chứa NaN/Inf.
+
+Nhấn **Run All** trong Jupyter hoặc VS Code để chạy.

--- a/part2/test.ipynb
+++ b/part2/test.ipynb
@@ -4,9 +4,11 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# Tài liệu Kiểm thử (Test Cases): Chéo hóa Ma trận và Phân rã SVD\n",
+        "# Test Cases: Chéo hóa Ma trận và Phân rã SVD\n",
         "\n",
-        "Dựa vào đặc tả trong `test.md`, Notebook này đóng vai trò tự động hóa việc đưa các ma trận thử nghiệm (với độ khó tăng dần và đầy đủ các trường hợp cạnh/lỗi) vào hai hàm cốt lõi `demo_diagonalize` và `demo_svd` nhằm rà soát tính ổn định của hệ thống."
+        "Đưa các ma trận thử nghiệm vào hai hàm cốt lõi `demo_diagonalize` và `demo_svd` nhằm rà soát tính ổn định của hệ thống.\n",
+        "\n",
+        "Mỗi phần bao gồm **5 test case** bao phủ: thường, biên và lỗi."
       ]
     },
     {
@@ -33,13 +35,12 @@
       "metadata": {},
       "source": [
         "---\n",
-        "### Test Case 1: Normal (Ma trận vuông không đối xứng, các trị riêng phân biệt)\n",
+        "### Test Case 1: Ma trận 2×2 không đối xứng, trị riêng phân biệt\n",
         "* **Input:**\n",
         "    $$A = \\begin{pmatrix} 62.5 & -18.2 \\\\ 108.3 & -37.1 \\end{pmatrix}$$\n",
         "* **Expected Value:**\n",
-        "    * **Trị riêng (Eigenvalues):** $\\lambda_1 \\approx 35.292$, $\\lambda_2 \\approx -9.892$.\n",
-        "    * **Ma trận đường chéo $D$:**\n",
-        "        $$D = \\begin{pmatrix} 35.292 & 0 \\\\ 0 & -9.892 \\end{pmatrix}$$"
+        "    * **Trị riêng (Eigenvalues):** $\\lambda_1 \\approx 35.26$, $\\lambda_2 \\approx -9.86$.\n",
+        "    * **Sai số tái cấu trúc** $\\|A - PDP^{-1}\\|_{\\max} < 10^{-4}$."
       ]
     },
     {
@@ -53,11 +54,11 @@
           "text": [
             "\n",
             "* Kết quả chéo hóa\n",
-            "Ma trận đổi cơ sở P (Các vector riêng nằm trên các cột):\n",
+            "Ma trận đổi cơ sở P:\n",
             "    0.5556   0.2439\n",
             "    0.8315   0.9698\n",
             "\n",
-            "Ma trận đường chéo D (Các giá trị riêng):\n",
+            "Ma trận đường chéo D:\n",
             "   35.2606   0.0000\n",
             "    0.0000  -9.8606\n",
             "\n",
@@ -65,7 +66,7 @@
             "    2.8867  -0.7260\n",
             "   -2.4750   1.6536\n",
             "* Kiểm chứng chéo hóa\n",
-            "Sai số tái cấu trúc ||A - P*D*P^-1||max = 4.26e-14\n",
+            "Sai số tái cấu trúc ||A - P*D*P^-1||max = 2.84e-14\n",
             "Cài đặt chéo hóa đúng (A ~ P*D*P^-1).\n",
             "Sai số giá trị riêng so với NumPy = 7.11e-15\n"
           ]
@@ -73,7 +74,7 @@
         {
           "data": {
             "text/plain": [
-              "np.True_"
+              "True"
             ]
           },
           "execution_count": 2,
@@ -93,13 +94,12 @@
       "metadata": {},
       "source": [
         "---\n",
-        "### Test Case 2: Boundary (Ma trận đối xứng, trị riêng lặp)giá trị $0$ (ma trận suy biến).\n",
+        "### Test Case 2: Ma trận 3×3 đối xứng, trị riêng phân biệt\n",
         "* **Input:**\n",
-        "    $$A = \\begin{pmatrix} 2 & -1 & -1 \\\\ -1 & 2 & -1 \\\\ -1 & -1 & 2 \\end{pmatrix}$$\n",
+        "    $$A = \\begin{pmatrix} 4 & 1 & 0 \\\\ 1 & 3 & 1 \\\\ 0 & 1 & 2 \\end{pmatrix}$$\n",
         "* **Expected Value:**\n",
-        "    * **Trị riêng:** $\\lambda_1 = 3$, $\\lambda_2 = 3$ (bội 2) và $\\lambda_3 = 0$.\n",
-        "    * **Ma trận đường chéo $D$:**\n",
-        "        $$D = \\begin{pmatrix} 3 & 0 & 0 \\\\ 0 & 3 & 0 \\\\ 0 & 0 & 0 \\end{pmatrix}$$\n"
+        "    * Ba trị riêng phân biệt (ma trận đối xứng luôn chéo hóa được).\n",
+        "    * **Sai số tái cấu trúc** $\\|A - PDP^{-1}\\|_{\\max} < 10^{-4}$."
       ]
     },
     {
@@ -113,12 +113,143 @@
           "text": [
             "\n",
             "* Kết quả chéo hóa\n",
-            "Ma trận đổi cơ sở P (Các vector riêng nằm trên các cột):\n",
+            "Ma trận đổi cơ sở P:\n",
+            "    0.7887  -0.5774   0.2113\n",
+            "    0.5774   0.5774  -0.5774\n",
+            "    0.2113   0.5774   0.7887\n",
+            "\n",
+            "Ma trận đường chéo D:\n",
+            "    4.7321   0.0000   0.0000\n",
+            "    0.0000   3.0000   0.0000\n",
+            "    0.0000   0.0000   1.2679\n",
+            "\n",
+            "Ma trận P^-1:\n",
+            "    0.7887   0.5774   0.2113\n",
+            "   -0.5774   0.5774   0.5774\n",
+            "    0.2113  -0.5774   0.7887\n",
+            "* Kiểm chứng chéo hóa\n",
+            "Sai số tái cấu trúc ||A - P*D*P^-1||max = 2.00e-15\n",
+            "Cài đặt chéo hóa đúng (A ~ P*D*P^-1).\n",
+            "Sai số giá trị riêng so với NumPy = 1.78e-15\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "True"
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "demo_diagonalize([\n",
+        "    [4, 1, 0],\n",
+        "    [1, 3, 1],\n",
+        "    [0, 1, 2]\n",
+        "])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### Test Case 3: Ma trận đường chéo 4×4\n",
+        "* **Input:**\n",
+        "    $$A = \\begin{pmatrix} 5 & 0 & 0 & 0 \\\\ 0 & -3 & 0 & 0 \\\\ 0 & 0 & 7 & 0 \\\\ 0 & 0 & 0 & 1 \\end{pmatrix}$$\n",
+        "* **Expected Value:**\n",
+        "    * $P = I_4$, $D = A$ (ma trận đường chéo tự đã chéo hóa).\n",
+        "    * **Sai số tái cấu trúc** $\\|A - PDP^{-1}\\|_{\\max} < 10^{-4}$."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "* Kết quả chéo hóa\n",
+            "Ma trận đổi cơ sở P:\n",
+            "    1.0000   0.0000   0.0000   0.0000\n",
+            "    0.0000   1.0000   0.0000   0.0000\n",
+            "    0.0000   0.0000   1.0000   0.0000\n",
+            "    0.0000   0.0000   0.0000   1.0000\n",
+            "\n",
+            "Ma trận đường chéo D:\n",
+            "    5.0000   0.0000   0.0000   0.0000\n",
+            "    0.0000  -3.0000   0.0000   0.0000\n",
+            "    0.0000   0.0000   7.0000   0.0000\n",
+            "    0.0000   0.0000   0.0000   1.0000\n",
+            "\n",
+            "Ma trận P^-1:\n",
+            "    1.0000   0.0000   0.0000   0.0000\n",
+            "    0.0000   1.0000   0.0000   0.0000\n",
+            "    0.0000   0.0000   1.0000   0.0000\n",
+            "    0.0000   0.0000   0.0000   1.0000\n",
+            "* Kiểm chứng chéo hóa\n",
+            "Sai số tái cấu trúc ||A - P*D*P^-1||max = 0.00e+00\n",
+            "Cài đặt chéo hóa đúng (A ~ P*D*P^-1).\n",
+            "Sai số giá trị riêng so với NumPy = 0.00e+00\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "True"
+            ]
+          },
+          "execution_count": 4,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "demo_diagonalize([\n",
+        "    [5, 0, 0, 0],\n",
+        "    [0, -3, 0, 0],\n",
+        "    [0, 0, 7, 0],\n",
+        "    [0, 0, 0, 1]\n",
+        "])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### Test Case 4: Ma trận 3×3 đối xứng, trị riêng lặp kèm giá trị 0 (suy biến)\n",
+        "* **Input:**\n",
+        "    $$A = \\begin{pmatrix} 2 & -1 & -1 \\\\ -1 & 2 & -1 \\\\ -1 & -1 & 2 \\end{pmatrix}$$\n",
+        "* **Expected Value:**\n",
+        "    * **Trị riêng:** $\\lambda_1 = \\lambda_2 = 3$, $\\lambda_3 = 0$.\n",
+        "    * Ma trận vẫn chéo hóa được vì đây là ma trận đối xứng.\n",
+        "    * **Sai số tái cấu trúc** $\\|A - PDP^{-1}\\|_{\\max} < 10^{-4}$."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "* Kết quả chéo hóa\n",
+            "Ma trận đổi cơ sở P:\n",
             "   -0.7071  -0.4082   0.5774\n",
             "    0.7071  -0.4082   0.5774\n",
             "    0.0000   0.8165   0.5774\n",
             "\n",
-            "Ma trận đường chéo D (Các giá trị riêng):\n",
+            "Ma trận đường chéo D:\n",
             "    3.0000   0.0000   0.0000\n",
             "    0.0000   3.0000   0.0000\n",
             "    0.0000   0.0000   0.0000\n",
@@ -128,18 +259,18 @@
             "   -0.4082  -0.4082   0.8165\n",
             "    0.5774   0.5774   0.5774\n",
             "* Kiểm chứng chéo hóa\n",
-            "Sai số tái cấu trúc ||A - P*D*P^-1||max = 7.49e-13\n",
+            "Sai số tái cấu trúc ||A - P*D*P^-1||max = 2.23e-08\n",
             "Cài đặt chéo hóa đúng (A ~ P*D*P^-1).\n",
-            "Sai số giá trị riêng so với NumPy = 7.49e-13\n"
+            "Sai số giá trị riêng so với NumPy = 2.23e-08\n"
           ]
         },
         {
           "data": {
             "text/plain": [
-              "np.True_"
+              "True"
             ]
           },
-          "execution_count": 3,
+          "execution_count": 5,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -157,25 +288,24 @@
       "metadata": {},
       "source": [
         "---\n",
-        "### Test Case 3: Error / Exception (Ma trận khiếm khuyết - Defective Matrix)\n",
+        "### Test Case 5: Ma trận khiếm khuyết, không chéo hóa được\n",
         "* **Input:**\n",
         "    $$A = \\begin{pmatrix} 5 & 4 & 2 \\\\ 0 & 5 & 1 \\\\ 0 & 0 & 5 \\end{pmatrix}$$\n",
         "* **Expected Value:**\n",
-        "    * **Trị riêng:** $\\lambda = 5$ (bội 3).\n",
-        "    * **Không gian vector riêng:** Số chiều của không gian vector riêng tương ứng với $\\lambda = 5$ nhỏ hơn 3.\n",
-        "    * Hệ thống phải bắt được ngoại lệ (Exception) hoặc trả về cờ trạng thái `False`"
+        "    * **Trị riêng:** $\\lambda = 5$ (bội 3), không gian riêng chỉ có 1 chiều.\n",
+        "    * Hệ thống phải ném `ValueError` do ma trận không đủ vector riêng độc lập."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 6,
       "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Lỗi: ZeroDivisionError -> division by zero\n"
+            "Lỗi: ValueError -> Lỗi: Ma trận không chéo hóa được: Không đủ n vector riêng độc lập tuyến tính.\n"
           ]
         }
       ],
@@ -203,17 +333,18 @@
       "metadata": {},
       "source": [
         "---\n",
-        "### Test Case 1: Normal (Ma trận chữ nhật, Full Hạng)\n",
+        "### Test Case 1: Ma trận 3×2 chữ nhật có nhiều dòng hơn cột\n",
         "* **Input:**\n",
         "    $$A = \\begin{pmatrix} 12.5 & 8.2 \\\\ 8.1 & 12.7 \\\\ 8.0 & -8.5 \\end{pmatrix}$$\n",
         "* **Expected Value:**\n",
-        "    * **Kích thước output:** $U$ là ma trận $3 \\times 3$, $\\Sigma$ là ma trận $3 \\times 2$, và $V^T$ là ma trận $2 \\times 2$.\n",
-        "    * **Giá trị suy biến (Singular Values):** Phải tồn tại 2 giá trị suy biến khác không ($\\sigma_1, \\sigma_2 > 0$) nằm trên đường chéo chính của $\\Sigma$, được sắp xếp giảm dần ($\\sigma_1 \\ge \\sigma_2$)."
+        "    * $U \\in \\mathbb{R}^{3 \\times 3}$, $\\Sigma \\in \\mathbb{R}^{3 \\times 2}$, $V^T \\in \\mathbb{R}^{2 \\times 2}$.\n",
+        "    * Hai giá trị kỳ dị $\\sigma_1 \\geq \\sigma_2 > 0$.\n",
+        "    * **Sai số tái cấu trúc** $\\|A - U\\Sigma V^T\\|_{\\max} < 10^{-4}$."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 7,
       "metadata": {},
       "outputs": [
         {
@@ -222,23 +353,23 @@
           "text": [
             "\n",
             "* Kết quả phân rã SVD\n",
-            "Ma trận U (Left Singular Vectors):\n",
+            "Ma trận U:\n",
             "    0.7009  -0.2754   0.6580\n",
             "    0.7125   0.2286  -0.6634\n",
             "   -0.0323  -0.9338  -0.3564\n",
             "\n",
-            "Ma trận kích thước m x n Sigma (Singular Values):\n",
+            "Ma trận Sigma:\n",
             "   20.7579   0.0000\n",
             "    0.0000  12.4799\n",
             "    0.0000   0.0000\n",
             "\n",
-            "Ma trận V^T (Right Singular Vectors Transposed):\n",
+            "Ma trận V^T:\n",
             "    0.6877   0.7260\n",
             "   -0.7260   0.6877\n",
             "* Kiểm chứng SVD\n",
-            "Sai số tái cấu trúc ||A - U*Sigma*V^T||max = 1.78e-15\n",
+            "Sai số tái cấu trúc ||A - U*Sigma*V^T||max = 3.55e-15\n",
             "Cài đặt SVD đúng (A ~ U*Sigma*V^T).\n",
-            "Sai số giá trị kỳ dị so với NumPy = 3.55e-15\n"
+            "Sai số giá trị kỳ dị so với NumPy = 1.78e-15\n"
           ]
         }
       ],
@@ -255,17 +386,17 @@
       "metadata": {},
       "source": [
         "---\n",
-        "### Test Case 2: Boundary (Ma trận hạng hụt / Rank-deficient)\n",
+        "### Test Case 2: Ma trận vuông 3×3, full hạng\n",
         "* **Input:**\n",
-        "    $$A = \\begin{pmatrix} 2.5 & -5.0 & 7.5 \\\\ 5.0 & -10.0 & 15.0 \\\\ -2.5 & 5.0 & -7.5 \\end{pmatrix}$$\n",
+        "    $$A = \\begin{pmatrix} 1 & 2 & 3 \\\\ 4 & 5 & 6 \\\\ 7 & 8 & 10 \\end{pmatrix}$$\n",
         "* **Expected Value:**\n",
-        "    * **Hạng của ma trận:** $r = 1$.\n",
-        "    * **Giá trị suy biến:** Chỉ có duy nhất 1 giá trị $\\sigma_1 > 0$. Các giá trị còn lại $\\sigma_2 \\approx 0$ và $\\sigma_3 \\approx 0$."
+        "    * Ba giá trị kỳ dị $\\sigma_1 \\geq \\sigma_2 \\geq \\sigma_3 > 0$.\n",
+        "    * **Sai số tái cấu trúc** $\\|A - U\\Sigma V^T\\|_{\\max} < 10^{-4}$."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 8,
       "metadata": {},
       "outputs": [
         {
@@ -274,24 +405,130 @@
           "text": [
             "\n",
             "* Kết quả phân rã SVD\n",
-            "Ma trận U (Left Singular Vectors):\n",
+            "Ma trận U:\n",
+            "    0.2093   0.9644   0.1617\n",
+            "    0.5038   0.0353  -0.8631\n",
+            "    0.8380  -0.2621   0.4785\n",
+            "\n",
+            "Ma trận Sigma:\n",
+            "   17.4125   0.0000   0.0000\n",
+            "    0.0000   0.8752   0.0000\n",
+            "    0.0000   0.0000   0.1969\n",
+            "\n",
+            "Ma trận V^T:\n",
+            "    0.4647   0.5538   0.6910\n",
+            "   -0.8333   0.0095   0.5528\n",
+            "    0.2995  -0.8326   0.4659\n",
+            "* Kiểm chứng SVD\n",
+            "Sai số tái cấu trúc ||A - U*Sigma*V^T||max = 1.78e-15\n",
+            "Cài đặt SVD đúng (A ~ U*Sigma*V^T).\n",
+            "Sai số giá trị kỳ dị so với NumPy = 3.55e-15\n"
+          ]
+        }
+      ],
+      "source": [
+        "demo_svd([\n",
+        "    [1, 2, 3],\n",
+        "    [4, 5, 6],\n",
+        "    [7, 8, 10]\n",
+        "])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### Test Case 3: Ma trận 2×4 có nhiều cột hơn dòng\n",
+        "* **Input:**\n",
+        "    $$A = \\begin{pmatrix} 1 & 2 & 3 & 4 \\\\ 5 & 6 & 7 & 8 \\end{pmatrix}$$\n",
+        "* **Expected Value:**\n",
+        "    * $U \\in \\mathbb{R}^{2 \\times 2}$, $\\Sigma \\in \\mathbb{R}^{2 \\times 4}$, $V^T \\in \\mathbb{R}^{4 \\times 4}$.\n",
+        "    * Tối đa 2 giá trị kỳ dị khác 0 (hạng $\\leq \\min(m,n) = 2$).\n",
+        "    * **Sai số tái cấu trúc** $\\|A - U\\Sigma V^T\\|_{\\max} < 10^{-4}$."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "* Kết quả phân rã SVD\n",
+            "Ma trận U:\n",
+            "    0.3762   0.9266\n",
+            "    0.9266  -0.3762\n",
+            "\n",
+            "Ma trận Sigma:\n",
+            "   14.2274   0.0000   0.0000   0.0000\n",
+            "    0.0000   1.2573   0.0000   0.0000\n",
+            "\n",
+            "Ma trận V^T:\n",
+            "    0.3521   0.4436   0.5352   0.6268\n",
+            "   -0.7590  -0.3212   0.1165   0.5542\n",
+            "    0.4082  -0.8165   0.4082  -0.0000\n",
+            "    0.3651  -0.1826  -0.7303   0.5477\n",
+            "* Kiểm chứng SVD\n",
+            "Sai số tái cấu trúc ||A - U*Sigma*V^T||max = 2.66e-15\n",
+            "Cài đặt SVD đúng (A ~ U*Sigma*V^T).\n",
+            "Sai số giá trị kỳ dị so với NumPy = 1.78e-15\n"
+          ]
+        }
+      ],
+      "source": [
+        "demo_svd([\n",
+        "    [1, 2, 3, 4],\n",
+        "    [5, 6, 7, 8]\n",
+        "])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "### Test Case 4: Ma trận hạng hụt\n",
+        "* **Input:**\n",
+        "    $$A = \\begin{pmatrix} 2.5 & -5.0 & 7.5 \\\\ 5.0 & -10.0 & 15.0 \\\\ -2.5 & 5.0 & -7.5 \\end{pmatrix}$$\n",
+        "* **Expected Value:**\n",
+        "    * Hạng của ma trận $r = 1$.\n",
+        "    * Chỉ có $\\sigma_1 > 0$; $\\sigma_2 \\approx \\sigma_3 \\approx 0$.\n",
+        "    * **Sai số tái cấu trúc** $\\|A - U\\Sigma V^T\\|_{\\max} < 10^{-4}$."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "* Kết quả phân rã SVD\n",
+            "Ma trận U:\n",
             "    0.4082   0.9129  -0.0000\n",
             "    0.8165  -0.3651   0.4472\n",
             "   -0.4082   0.1826   0.8944\n",
             "\n",
-            "Ma trận kích thước m x n Sigma (Singular Values):\n",
+            "Ma trận Sigma:\n",
             "   22.9129   0.0000   0.0000\n",
             "    0.0000   0.0000   0.0000\n",
             "    0.0000   0.0000   0.0000\n",
             "\n",
-            "Ma trận V^T (Right Singular Vectors Transposed):\n",
+            "Ma trận V^T:\n",
             "    0.2673  -0.5345   0.8018\n",
             "    0.8944   0.4472   0.0000\n",
             "   -0.3586   0.7171   0.5976\n",
             "* Kiểm chứng SVD\n",
-            "Sai số tái cấu trúc ||A - U*Sigma*V^T||max = 3.55e-15\n",
+            "Sai số tái cấu trúc ||A - U*Sigma*V^T||max = 7.10e-10\n",
             "Cài đặt SVD đúng (A ~ U*Sigma*V^T).\n",
-            "Sai số giá trị kỳ dị so với NumPy = 7.11e-15\n"
+            "Sai số giá trị kỳ dị so với NumPy = 8.69e-10\n"
           ]
         }
       ],
@@ -308,16 +545,16 @@
       "metadata": {},
       "source": [
         "---\n",
-        "### Test Case 3: Error / Edge (Dữ liệu đầu vào bất hợp lệ)\n",
+        "### Test Case 5: Ma trận chứa giá trị NaN/Inf không hợp lệ\n",
         "* **Input:**\n",
         "    $$A = \\begin{pmatrix} 1.4 & \\text{NaN} \\\\ \\text{Inf} & 3.2 \\end{pmatrix}$$\n",
         "* **Expected Value:**\n",
-        "    * Hệ thống không được lặp vô hạn hay xử lý ngầm và ra kết quả sai. Bắt buộc phải văng ngoại lệ báo lỗi liên quan đến giá trị bất hợp lệ."
+        "    * Hệ thống phải ném `ValueError` báo lỗi giá trị bất hợp lệ, không được xử lý ngầm."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 11,
       "metadata": {},
       "outputs": [
         {


### PR DESCRIPTION
## Tóm tắt
Pull request này hoàn thiện **part2**. 
Đảm bảo khả năng mở rộng, độ chính xác cao và xử lý sạch sẽ các ngoại lệ (edge cases/errors) của ma trận.

## Chi tiết các module đã triển khai
1. **`diagonalization.py` (Thuật toán Chéo hóa ma trận)**
   - **Tính đa thức đặc trưng:** Sử dụng thuật toán `Faddeev-LeVerrier` để sinh ra các hệ số của đa thức một cách ổn định.
   - **Tìm giá trị riêng:** Cài đặt phương pháp lặp song song `Durand-Kerner (Weierstrass)` trên trường số phức để tự động tìm rễ đa thức (giá trị riêng).
   - **Tìm không gian riêng:** Kế thừa bộ giải `rank_and_basis` (Khử Gauss) từ `part1` nhằm trích xuất null space chính xác.
   - **Thẩm định tự động:** Kiểm chứng các ma trận có thể phân rã $A = P \cdot D \cdot P^{-1}$ hay bị khuyết. Nếu thiếu vector độc lập tuyến tính, hệ thống tự động `raise ValueError`.

2. **`decomposition.py` (Phân rã SVD - Singular Value Decomposition)**
   - Triển khai thuật toán $A = U \cdot \Sigma \cdot V^T$ cho mọi loại ma trận vuông, chữ nhật, suy biến.
   - Tái sử dụng `find_eigen` từ module chéo hoá cho ma trận đối xứng $A^T \cdot A$ để truy xuất $V$ và $\Sigma$.
   - Tính toán phần $U$ thông qua phép biến đổi $A \cdot v_i / \sigma_i$ đối với $\sigma_i > 0$.
   - Sử dụng `Gram-Schmidt` để lấp đầy các chiều vector null còn thiếu, bảo đảm $U$ và $V$ duy trì tính trực giao $Q^T \cdot Q = I$.

3. **`test.ipynb` (Kiểm thử hệ thống)**
   - 10 test cases cho 2 phần chéo hóa và svd, mỗi phần 5 cases.
   - Gồm các trường hợp bình thường (Normal), ranh giới (Boundary - ma trận suy biến/hạng hụt), và cố ý bắt lỗi (Error - chứa NaN/Inf, ma trận khiếm khuyết không chéo hóa được).
   - Sai số tái cấu trúc đều được ràng buộc nghiệm thu $< 10^{-4}$ (so sánh trực tiếp với NumPy).

## Checklist kiểm tra
- [x] Code không sử dụng thư viện cấm như `np.linalg.solve`, `sympy` (chỉ dùng NumPy để kiểm chứng).
- [x] Đã xử lý các edge cases: NaN, Inf, ma trận rỗng.
- [x] Viết `readme.md` đầy đủ.
- [x] Pass toàn bộ test case với độ lệch $\le 10^{-4}$.
- [x] Kế thừa các module từ part1

## Các vấn cần lưu ý
- Trong `diagonalization.py`, do giới hạn của phương pháp tìm rễ đa thức, code thuần thiết lập mức trần là kích thước $n \le 4$. Nếu lớn hơn, sẽ fallback sang `numpy` như cơ chế dự phòng an toàn.